### PR TITLE
Update beach monitoring to use new CoSD OutSystems API

### DIFF
--- a/data/beach_water_quality/note.md
+++ b/data/beach_water_quality/note.md
@@ -1,39 +1,111 @@
 
- South Region Gastrointestinal Illness Concerns
-https://www.sandiegocounty.gov/content/sdc/hhsa/programs/phs/community_epidemiology/GI-Concerns.html
- 
-https://www.sdbeachinfo.com/
+## SD Beach Info (Current Status / Advisories / Closures)
 
-data:
-POST
-https://beachwatch.waterboards.ca.gov/public/result.php
-Form Data
+**New site (as of ~2025):**
+https://cosdapps.sandiegocounty.gov/sdbeachinfo/
 
-County=10&stationID=&parameter=&qualifier=&method=&created=&year=2024&sort=%60SampleDate%60&sortOrder=DESC&submit=Search
+The old site (www.sdbeachinfo.com) now redirects here. The new site is an OutSystems reactive web app.
 
-To GEt Closure information over time:
+### CoSD OutSystems API
+
+The new site requires JavaScript-initialized session cookies (`nr1Users`, `nr2Users`, `osVisitor`, `osVisit`) and an `X-CSRFToken` header (extracted from the `crf=` field in the URL-decoded `nr2Users` cookie). Plain HTTP requests get 403. Use Playwright to load the page first.
+
+All endpoints are POSTed to:
+```
+https://cosdapps.sandiegocounty.gov/sdbeachinfo/screenservices/CoSD_Beach_Water_CW/MainFlow/<Block>/<ActionName>
+```
+
+Request body structure:
+```json
+{
+  "versionInfo": {"moduleVersion": "<token from /moduleservices/moduleversioninfo>", "apiVersion": "<captured at runtime>"},
+  "viewName": "MainFlow.Home",
+  "screenData": {"variables": {...}},
+  "inputParameters": {"StartIndex": 0, "MaxRecords": 900}
+}
+```
+
+**Get module version:**
+GET `https://cosdapps.sandiegocounty.gov/sdbeachinfo/moduleservices/moduleversioninfo`
+Returns `{"versionToken": "..."}` — pass as `moduleVersion` in all requests.
+
+**Key endpoints (HomeBlockNew):**
+
+`ScreenDataSetGetSiteById` — returns site list filtered by EventTypeId:
+- `EventTypeId: 0` → all 89 monitoring sites with coordinates
+- `EventTypeId: 1` → advisory sites only
+- `EventTypeId: 2` → closure sites only
+
+apiVersion: captured at runtime from intercepted browser requests (changes with deployments).
+Screen variables: `ShowDetails, MapCenter, SiteIdAux, EventTypeId, ZoomCurrent, id, _idInDataFetchStatus`
+
+**Key endpoints (BlockMarkup):**
+
+`ScreenDataSetGetEventsList` — event history for a single site:
+- Screen variables: `{"SiteId": "<id>", "_siteIdInDataFetchStatus": 1}`
+- apiVersion: `JqlpdF6Psvnxe_pXo1Jjtw` (as of 2026-06)
+- Returns events with `IssueDateTime`, `StatusId`, `DescriptionIssue`
+
+`ScreenDataSetGetEventsData` — detailed event data for a site
+- apiVersion: `CbxGxYvKg93xpMEAMzMgPw` (as of 2026-06)
+
+`ScreenDataSetGetEvents` — event data (another variant)
+- apiVersion: `X6kHzOPIWzBFjbOVvF8Oog` (as of 2026-06)
+
+`ScreenDataSetGetEventsIsActive` — whether a site's event is currently active
+- apiVersion: `_NIYQ5IUUP_BTHGXD24HHQ` (as of 2026-06)
+
+### Site data returned by GetSiteById
+Each site has: `Id`, `LocationName`, `BeachName`, `City`, `Region`, `Latitude`, `Longitude`, `Description`, `StatusId`
+
+Note: `StatusId` in region list endpoints (`GetRegionsSouth`, `GetRegionsCentral`, `GetRegionsNort`) is always 0 — do NOT use those to determine status. Use `EventTypeId` filter on `GetSiteById` instead.
+
+### Historical Closures / Advisory Archive
+
+Historical closure info over time:
 https://www.waterboards.ca.gov/water_issues/programs/beaches/search_beach_advisory.html
 
-Beachwatch Status Descriptions:
-https://www.sdbeachinfo.com/Home/GetTargetByID
+---
 
+## CA BeachWatch (Sample Analysis Data)
+
+POST to get results page (sets session cookies):
+```
+https://beachwatch.waterboards.ca.gov/public/result.php
+Form: County=10&stationID=&parameter=&qualifier=&method=&created=&year=2024&sort=`SampleDate`&sortOrder=DESC&submit=Search
+```
+
+Then GET to download CSV (uses cookies from above):
+```
+https://beachwatch.waterboards.ca.gov/public/export.php
+```
 
 ---
-san diego water quailty github
 
-https://github.com/san-diego-water-quality/water-quality-project
+## South Region GI Illness Concerns
 
--- now cast:
-https://github.com/rtsearcy/NowCast
+https://www.sandiegocounty.gov/content/sdc/hhsa/programs/phs/community_epidemiology/GI-Concerns.html
+
+---
+
+## California Safe to Swim Data
+
+https://mywaterquality.ca.gov/safe-to-swim/content/interactive_map/index.html
+
+Sites: https://data.ca.gov/dataset/surface-water-fecal-indicator-bacteria-results/resource/848d2e3f-2846-449c-90e0-9aaf5c45853e
+Geometric means: https://data.ca.gov/dataset/surface-water-fecal-indicator-bacteria-results/resource/15a63495-8d9f-4a49-b43a-3092ef3106b9
+https://data.ca.gov/dataset/surface-water-fecal-indicator-bacteria-results/resource/1987c159-ce07-47c6-8d4f-4483db6e6460
+
+---
+
+## Related Resources
 
 EPA Beacon:
 https://beacon.epa.gov/ords/beacon2/r/beacon_apex/beacon2/map-page
 Standards: https://beacon.epa.gov/ords/beacon2/r/beacon_apex/beacon2/beach-profile-details?beach_id=CA068221&year=2024&debug=YES
 
+San Diego Water Quality GitHub:
+https://github.com/san-diego-water-quality/water-quality-project
 
-Claifonria safe to swim data:
-https://mywaterquality.ca.gov/safe-to-swim/content/interactive_map/index.html
-
-sites: https://data.ca.gov/dataset/surface-water-fecal-indicator-bacteria-results/resource/848d2e3f-2846-449c-90e0-9aaf5c45853e
-geometric means: https://data.ca.gov/dataset/surface-water-fecal-indicator-bacteria-results/resource/15a63495-8d9f-4a49-b43a-3092ef3106b9
-https://data.ca.gov/dataset/surface-water-fecal-indicator-bacteria-results/resource/1987c159-ce07-47c6-8d4f-4483db6e6460
+NowCast model:
+https://github.com/rtsearcy/NowCast

--- a/workflows/resilient_core/src/resilient_core/utils/constants.py
+++ b/workflows/resilient_core/src/resilient_core/utils/constants.py
@@ -6,6 +6,7 @@ ICONS = {
     "h2s": 'circle',
     "complaints":'pin',
     'Red':'beach',
+    'Orange':'beach',
     'Yellow':'beach',
     'Green':'beach',
     'Black':'outfall'

--- a/workflows/tijuana/src/tijuana/assets/beach_monitoring.py
+++ b/workflows/tijuana/src/tijuana/assets/beach_monitoring.py
@@ -1,6 +1,7 @@
 import requests
 import os
 import re
+import urllib.parse
 from dagster import ( asset,
                      get_dagster_logger,
                       TimeWindowPartitionsDefinition,
@@ -33,6 +34,34 @@ reports_page=f"{baseurl}result.php"
 exports_page=f"{baseurl}export.php"
 
 s3_output_path = 'tijuana/beachwatch'
+
+# New CoSD beach info site (replaced www.sdbeachinfo.com)
+COSD_BEACH_URL = "https://cosdapps.sandiegocounty.gov/sdbeachinfo/"
+COSD_HOME_BLOCK = "screenservices/CoSD_Beach_Water_CW/MainFlow/HomeBlockNew"
+COSD_BLOCK_MARKUP = "screenservices/CoSD_Beach_Water_CW/MainFlow/BlockMarkup"
+
+# EventTypeId values from the CoSD API
+COSD_EVENT_TYPE_ADVISORY = 1
+COSD_EVENT_TYPE_CLOSURE = 2
+
+# Map CoSD EventTypeId to old IndicatorID (for backward compatibility)
+COSD_EVENT_TYPE_TO_INDICATOR = {
+    COSD_EVENT_TYPE_CLOSURE: 1,   # Closure → IndicatorID 1
+    2: 2,                          # Open (no event) → IndicatorID 2
+    COSD_EVENT_TYPE_ADVISORY: 3,  # Advisory → IndicatorID 3
+}
+
+STATUS_COLOR = {
+    'Closure': 'Red',
+    'Advisory': 'Orange',
+    'Open': 'Green',
+    'Warning': 'Yellow',
+}
+
+STATUS_LABEL = {
+    COSD_EVENT_TYPE_ADVISORY: 'Advisory',
+    COSD_EVENT_TYPE_CLOSURE: 'Closure',
+}
 
 formdata={
    "County":10,
@@ -125,156 +154,316 @@ def beachwatch_closure_clean_data(beach_df) -> gpd.GeoDataFrame:
     #each_gdf=beach_gdf.drop(['date', 'time', 'id', 'Station_ID'], axis=1)
     beach_gdf['Icons'] = ICONS['beach']
     return beach_gdf
-''' This is used to parse the Date of the Advisory/Closure notices from the SD Beach Info website'''
-def parseSince(message):
-    date_str = ""
-    pattern=re.compile(
-        r"<strong>Status Since:\s*</strong>\s*(?:&nbsp;)*\s*([A-Za-z]+\s+\d{1,2},\s*\d{4})(?:&nbsp;)*",
-        re.IGNORECASE
-    )
-    match = pattern.search(message)
-    if match:
-        date_str = match.group(1)
-        get_dagster_logger().debug(f"Extracted date: {date_str}", )
-        dt = datetime.datetime.strptime(date_str, "%B %d, %Y")
-        date_str = dt.strftime("%b {day}, %Y").format(day=dt.day)
-        get_dagster_logger().debug(f"Modified date: {date_str}")
-    else:
-        print("No date found.")
-    get_dagster_logger().debug(f" Since: {date_str}")
-    return date_str
+###########################
+### CoSD Beach Info Scraper (new site: cosdapps.sandiegocounty.gov)
+### Replaces the old www.sdbeachinfo.com/Home/GetTargetByID endpoint
+###########################
 
-''' This is used to parse the Basic Content of the Advisory/Closure notices from the SD Beach Info website'''
-def parseNote(message):
-    pattern = re.compile(r"<strong>(.*?)</strong>", re.DOTALL)
-    matches = pattern.findall(message)
-    get_dagster_logger().debug(f" statusNote match: {matches}")
-    if matches is not None  and len(matches) > 0:
-        statusNote = matches[len(matches)- 1]
-    else:
-        statusNote="";
-    get_dagster_logger().debug(f" statusNote: {statusNote}")
-    return statusNote
-''' This is used to parse the Advisory/Closure notices from the SD Beach Info website'''
-def parseSdBeachinfoRow( row):
-    status = ""
-    statusNote = ""
-    get_dagster_logger().debug(f" IndicatorID: {row['IndicatorID']}")
-    if row['IndicatorID']== 1 and (row['Closure'] is not None and row['Closure'] !=''):
-        get_dagster_logger().debug(f" row['Closure']: {row['Closure']}")
-        status = parseSince(row['Closure'])
-        statusNote = parseNote(row['Closure'])
-    elif row['IndicatorID'] == 3 and (row['Advisory'] is not None and row['Advisory'] != ''):
-        get_dagster_logger().debug(f" row['Advisory']: {row['Advisory']}")
-        status = parseSince(row['Advisory'])
-        statusNote = parseNote(row['Advisory'])
-    return [status, statusNote]
-def removeMapLegendLink(html_string):
-    ''' Removes the map links which often point to the page.
-    tried many regex's but they never all succeeded.  Even when chatgpt was asked to write one for all 17,
-    never fully worked. '''
-    if html_string is None:
-        return ""
-    link = '<a href="/">Full County Map</a>&nbsp; <strong>|</strong> &nbsp;<a href="http://www.sandiegocounty.gov/content/dam/sdc/deh/lwqd/Beach&amp;Bay/bb_map_key_v.1.pdf">Map Legend</a>'
-    linkv2 = '<span style="font-size:medium"><span style="color:#000000"><span style="font-family:Calibri">.</span></span><strong><span style="font-family:&quot;Calibri&quot;,sans-serif"><span style="color:#000000">&nbsp;</span><a href="/"><span style="color:#0000ff">Full County Map</span></a><span style="color:#000000">&nbsp; | &nbsp;</span><a href="http://www.sandiegocounty.gov/content/dam/sdc/deh/lwqd/Beach&amp;Bay/bb_maplegend.pdf"><span style="color:#0000ff">Map Legend</span></a></span></strong></span>'
-    linkv3 = '<strong><a href="http://www.sandiegocounty.gov/content/dam/sdc/deh/lwqd/Beach&amp;Bay/bb_maplegend.pdf">Map Legend</a></strong>'
-    linkv4 = '<a href="http://www.sandiegocounty.gov/content/dam/sdc/deh/lwqd/Beach&Bay/bb_maplegend.pdf"><strong><span style="color:#0563c1">Map Legend</span></strong></a>'
-    linkv5 = '<strong><a href="http://www.sandiegocounty.gov/content/dam/sdc/deh/lwqd/Beach&amp;Bay/bb_maplegend.pdf">Map Legend</a>&nbsp;</strong>'
-    linkv6 = '<strong>&nbsp;<a href="http://www.sandiegocounty.gov/content/dam/sdc/deh/lwqd/Beach&amp;Bay/bb_maplegend.pdf">Map Legend</a></strong>'
-    linkv7 = '<a href="http://www.sandiegocounty.gov/content/dam/sdc/deh/lwqd/Beach&amp;Bay/bb_maplegend.pdf"><strong><span style="color:#0563c1">Map Legend</span></strong></a>'
-    linkv8 = '<strong>&nbsp;<a href="/"><span style="color:#0066cc">Full County Map</span></a>&nbsp; | &nbsp;<a href="http://www.sandiegocounty.gov/content/dam/sdc/deh/lwqd/Beach&amp;Bay/bb_maplegend.pdf"><span style="color:#0066cc">Map Legend</span></a></strong>'
-    linkv9 = '<strong><a href="/">Full County Map</a>&nbsp; | &nbsp;<a href="http://www.sandiegocounty.gov/content/dam/sdc/deh/lwqd/Beach&amp;Bay/bb_maplegend.pdf">Map Legend</a></strong>'
-    linkv10 = '<strong><a href="/"><span style="color:#0066cc">Full County Map</span></a>&nbsp; | &nbsp;<a href="http://www.sandiegocounty.gov/content/dam/sdc/deh/lwqd/Beach&amp;Bay/bb_maplegend.pdf"><span style="color:#0066cc">Map Legend</span></a></strong>'
-    link11 = '<a href="http://www.sandiegocounty.gov/content/dam/sdc/deh/lwqd/Beach&amp;Bay/bb_maplegend.pdf"><strong>Map Legend</strong></a>'
-    link12 = '<strong><a href="/"><span style="color:#0066cc">Full County Map</span></a>&nbsp; | &nbsp;<a href="http://www.sandiegocounty.gov/content/dam/sdc/deh/lwqd/Beach&amp;Bay/bb_maplegend.pdf"><span style="color:#0066cc">Map Legend</span></a>&nbsp;</strong>'
-    link13 = '<strong>&nbsp;<a href="http://www.sandiegocounty.gov/content/dam/sdc/deh/lwqd/Beach&amp;Bay/bb_maplegend.pdf"><span style="color:#0066cc">Map Legend</span></a></strong>'
-    link14 = '<strong><a href="https://admin.sdbeachinfo.com/"><span style="color:#0066cc">Full County Map</span></a>&nbsp; | <a href="http://www.sandiegocounty.gov/content/dam/sdc/deh/lwqd/Beach&amp;Bay/bb_maplegend.pdf"><span style="color:#0066cc">Map Legend</span></a></strong>'
-    link15 = '<strong><a href="http://www.sandiegocounty.gov/content/dam/sdc/deh/lwqd/Beach&amp;Bay/bb_maplegend.pdf"><span style="color:#0066cc">Map Legend</span></a></strong>'
-    link16 = '<a href="http://www.sandiegocounty.gov/content/dam/sdc/deh/lwqd/Beach&amp;Bay/bb_maplegend.pdf">Map Legend</a>'
-    link17 = '<a href="http://www.sandiegocounty.gov/content/dam/sdc/deh/lwqd/Beach&amp;Bay/bb_maplegend.pdf"><strong>&nbsp;Map Legend</strong></a>'
-    html_string=html_string.replace(link,'').replace(linkv2,'').replace(linkv3,'').replace(linkv4,'').replace(linkv5,'').replace(linkv6,'').replace(linkv7,'').replace(linkv8,'').replace(linkv9,'').replace(linkv10,'').replace(link11,'').replace(link12,'').replace(link13,'').replace(link14,'').replace(link15,'').replace(link16,' ').replace(link17,'')
-    return html_string
+def _cosd_make_fetch_js(url, module_version, api_version, screen_data_vars, input_params, csrf_token):
+    """Returns JS code string to make a POST request from within the Playwright browser context."""
+    return f"""
+    async () => {{
+        const resp = await fetch('{url}', {{
+            method: 'POST',
+            headers: {{
+                'Content-Type': 'application/json; charset=UTF-8',
+                'Accept': 'application/json',
+                'X-CSRFToken': {json.dumps(csrf_token)},
+            }},
+            credentials: 'include',
+            body: JSON.stringify({{
+                "versionInfo": {{"moduleVersion": {json.dumps(module_version)}, "apiVersion": {json.dumps(api_version)}}},
+                "viewName": "MainFlow.Home",
+                "screenData": {{"variables": {json.dumps(screen_data_vars)}}},
+                "inputParameters": {json.dumps(input_params)}
+            }})
+        }});
+        return {{status: resp.status, data: await resp.json()}};
+    }}
+    """
 
-def sdbeachinfo_clean_data(beachinfo_df) -> gpd.GeoDataFrame:
-    indicator2status = {
-        1: 'Closure',
-        2: 'Open',
-        3: 'Advisory',
-        4: 'Outfall'
-        #'Warning' # never seen a number
-    }
-    typeId2type ={
-        1: 'Monitoring Point',
-        2: 'Outfall'
-    }
-     # beach_df['date']=  pd.to_datetime(f'{beach_df["SampleDate"]}T{beach_df["SampleTime"]}')#, format='%Y-%m-%d %H:%M:%S')
-    gs = gpd.GeoSeries.from_xy(beachinfo_df['Longitude'], beachinfo_df['Latitude'])
-    beachinfo_gdf = gpd.GeoDataFrame(beachinfo_df, geometry=gs, crs='EPSG:4326')
-    beachinfo_gdf['Icon'] = ICONS['beach']
 
-    beachinfo_gdf['RBGColor'] = beachinfo_gdf['RBGColor'].map(lambda x: x.strip().replace('.png', '').replace('Outfall', 'Black'))
-    beachinfo_gdf['Icon'] = beachinfo_gdf['RBGColor'].map(lambda x: ICONS[x])
-    beachinfo_gdf['beachStatus'] =  beachinfo_gdf['IndicatorID'].apply(lambda i: indicator2status[i] )
-    beachinfo_gdf['LocationType'] = beachinfo_gdf['TypeID'].apply(lambda i: typeId2type[i])
-    beachinfo_gdf[['StatusSince','StatusNote']] = beachinfo_gdf.apply(parseSdBeachinfoRow,axis=1, result_type='expand')
-    beachinfo_gdf['Descirption_original']=beachinfo_gdf['Description']
-    beachinfo_gdf['Description']=beachinfo_gdf['Description'].apply(removeMapLegendLink)
-    return beachinfo_gdf
+def cosd_get_beach_status() -> list[dict]:
+    """
+    Fetch all beach monitoring sites and their current advisory/closure status
+    from the CoSD OutSystems beach info app.
+
+    Returns a list of site dicts with status, coordinates, and event details.
+    """
+    from playwright.sync_api import sync_playwright
+
+    sites_by_id = {}
+    advisory_ids = set()
+    closure_ids = set()
+    event_details = {}
+    captured_api_versions = {}
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(
+            headless=True,
+            args=['--ignore-certificate-errors', '--no-sandbox', '--disable-dev-shm-usage']
+        )
+        context = browser.new_context(
+            ignore_https_errors=True,
+            user_agent='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+        )
+        page = context.new_page()
+
+        def on_request(request):
+            if 'screenservices' in request.url:
+                try:
+                    payload = json.loads(request.post_data or '{}')
+                    vi = payload.get('versionInfo', {})
+                    name = request.url.split('/')[-1].split('?')[0]
+                    if vi.get('apiVersion'):
+                        captured_api_versions[name] = {
+                            'apiVersion': vi['apiVersion'],
+                            'moduleVersion': vi['moduleVersion'],
+                            'url': request.url,
+                        }
+                except Exception:
+                    pass
+
+        page.on('request', on_request)
+        page.goto(COSD_BEACH_URL, wait_until='networkidle', timeout=45000)
+        page.wait_for_timeout(3000)
+
+        # Get current module version
+        mv_resp = page.request.get(f"{COSD_BEACH_URL}moduleservices/moduleversioninfo")
+        module_version = mv_resp.json().get('versionToken', '')
+        get_dagster_logger().info(f"CoSD module version: {module_version}")
+
+        # Extract CSRF token from nr2Users cookie
+        cookies = {c['name']: c['value'] for c in context.cookies()}
+        nr2 = urllib.parse.unquote(cookies.get('nr2Users', ''))
+        csrf_token = next((part[4:] for part in nr2.split(';') if part.startswith('crf=')), '')
+        get_dagster_logger().info(f"CoSD CSRF token obtained: {bool(csrf_token)}")
+
+        # Get apiVersion for GetSiteById from captured requests (loaded on page init)
+        get_site_api_version = captured_api_versions.get('ScreenDataSetGetSiteById', {}).get('apiVersion', 'dPYSR+2HPtITJ2nn6p+WaQ')
+
+        def call_get_site_by_id(event_type_id: int) -> list[dict]:
+            url = f"{COSD_BEACH_URL}{COSD_HOME_BLOCK}/ScreenDataSetGetSiteById"
+            screen_vars = {
+                "ShowDetails": True, "MapCenter": "33.001319,-117.278388",
+                "SiteIdAux": "0", "EventTypeId": event_type_id,
+                "ZoomCurrent": 8, "id": "1", "_idInDataFetchStatus": 1
+            }
+            js = _cosd_make_fetch_js(url, module_version, get_site_api_version, screen_vars,
+                                     {"StartIndex": 0, "MaxRecords": 900}, csrf_token)
+            result = page.evaluate(f"({js})()")
+            if result.get('status') != 200:
+                get_dagster_logger().warning(f"GetSiteById EventTypeId={event_type_id} returned {result.get('status')}")
+                return []
+            if result.get('data', {}).get('versionInfo', {}).get('hasApiVersionChanged'):
+                get_dagster_logger().warning("GetSiteById: apiVersion has changed — results may be stale")
+            return result.get('data', {}).get('data', {}).get('List', {}).get('List', [])
+
+        def call_get_events_list(site_id: str) -> list[dict]:
+            # apiVersion from user-captured curl; detect changes via hasApiVersionChanged
+            api_version = 'JqlpdF6Psvnxe_pXo1Jjtw'
+            url = f"{COSD_BEACH_URL}{COSD_BLOCK_MARKUP}/ScreenDataSetGetEventsList"
+            screen_vars = {"SiteId": site_id, "_siteIdInDataFetchStatus": 1}
+            js = _cosd_make_fetch_js(url, module_version, api_version, screen_vars,
+                                     {"StartIndex": 0, "MaxRecords": 50}, csrf_token)
+            result = page.evaluate(f"({js})()")
+            if result.get('status') != 200:
+                get_dagster_logger().warning(f"GetEventsList site={site_id} returned {result.get('status')}")
+                return []
+            if result.get('data', {}).get('versionInfo', {}).get('hasApiVersionChanged'):
+                get_dagster_logger().warning(f"GetEventsList: apiVersion changed for site {site_id}")
+            return result.get('data', {}).get('data', {}).get('List', {}).get('List', [])
+
+        # Step 1: Get all 89+ monitoring sites with coordinates
+        all_site_items = call_get_site_by_id(0)
+        get_dagster_logger().info(f"CoSD: fetched {len(all_site_items)} total sites")
+        for item in all_site_items:
+            site_id = item.get('Id', '')
+            sites_by_id[site_id] = {
+                'SiteID': site_id,
+                'DehID': site_id,
+                'Name': item.get('LocationName', ''),
+                'BeachName': item.get('BeachName', ''),
+                'City': item.get('City', ''),
+                'Region': item.get('Region', ''),
+                'Latitude': float(item.get('Latitude', 0) or 0),
+                'Longitude': float(item.get('Longitude', 0) or 0),
+                'Description': item.get('Description', ''),
+                'beachStatus': 'Open',
+                'IndicatorID': 2,
+                'Active': True,
+                'RBGColor': 'Green',
+                'Advisory': '',
+                'Closure': '',
+                'StatusSince': '',
+                'StatusNote': '',
+                'LocationType': 'Monitoring Point',
+            }
+
+        # Step 2: Mark advisory sites (EventTypeId=1)
+        advisory_items = call_get_site_by_id(COSD_EVENT_TYPE_ADVISORY)
+        get_dagster_logger().info(f"CoSD: {len(advisory_items)} advisory sites")
+        for item in advisory_items:
+            site_id = item.get('Id', '')
+            advisory_ids.add(site_id)
+            if site_id in sites_by_id:
+                sites_by_id[site_id]['beachStatus'] = 'Advisory'
+                sites_by_id[site_id]['IndicatorID'] = 3
+                sites_by_id[site_id]['RBGColor'] = 'Orange'
+            else:
+                # Site appeared in advisory list but not in all-sites (use advisory item data)
+                sites_by_id[site_id] = {
+                    'SiteID': site_id, 'DehID': site_id,
+                    'Name': item.get('LocationName', ''), 'BeachName': item.get('BeachName', ''),
+                    'City': item.get('City', ''), 'Region': item.get('Region', ''),
+                    'Latitude': float(item.get('Latitude', 0) or 0),
+                    'Longitude': float(item.get('Longitude', 0) or 0),
+                    'Description': item.get('Description', ''),
+                    'beachStatus': 'Advisory', 'IndicatorID': 3, 'Active': True,
+                    'RBGColor': 'Orange', 'Advisory': '', 'Closure': '',
+                    'StatusSince': '', 'StatusNote': '', 'LocationType': 'Monitoring Point',
+                }
+
+        # Step 3: Mark closure sites (EventTypeId=2)
+        closure_items = call_get_site_by_id(COSD_EVENT_TYPE_CLOSURE)
+        get_dagster_logger().info(f"CoSD: {len(closure_items)} closure sites")
+        for item in closure_items:
+            site_id = item.get('Id', '')
+            closure_ids.add(site_id)
+            if site_id in sites_by_id:
+                sites_by_id[site_id]['beachStatus'] = 'Closure'
+                sites_by_id[site_id]['IndicatorID'] = 1
+                sites_by_id[site_id]['RBGColor'] = 'Red'
+            else:
+                sites_by_id[site_id] = {
+                    'SiteID': site_id, 'DehID': site_id,
+                    'Name': item.get('LocationName', ''), 'BeachName': item.get('BeachName', ''),
+                    'City': item.get('City', ''), 'Region': item.get('Region', ''),
+                    'Latitude': float(item.get('Latitude', 0) or 0),
+                    'Longitude': float(item.get('Longitude', 0) or 0),
+                    'Description': item.get('Description', ''),
+                    'beachStatus': 'Closure', 'IndicatorID': 1, 'Active': True,
+                    'RBGColor': 'Red', 'Advisory': '', 'Closure': '',
+                    'StatusSince': '', 'StatusNote': '', 'LocationType': 'Monitoring Point',
+                }
+
+        # Step 4: Get event details (issue date, description) for affected sites
+        affected_ids = advisory_ids | closure_ids
+        get_dagster_logger().info(f"CoSD: fetching event details for {len(affected_ids)} affected sites")
+        for site_id in affected_ids:
+            events = call_get_events_list(site_id)
+            if events:
+                event_details[site_id] = events[0]  # most recent event
+
+        browser.close()
+
+    # Step 5: Merge event details into site records
+    for site_id, event_item in event_details.items():
+        if site_id not in sites_by_id:
+            continue
+        site = sites_by_id[site_id]
+        event = event_item.get('Event', {})
+        event_type = event_item.get('EventType', {})
+        city_label = event_item.get('City', {}).get('Label', '')
+
+        # Parse issue datetime
+        issue_dt_str = event.get('IssueDateTime', '')
+        status_since = ''
+        if issue_dt_str and not issue_dt_str.startswith('1900'):
+            try:
+                dt = datetime.datetime.fromisoformat(issue_dt_str.replace('Z', '+00:00'))
+                status_since = dt.strftime(f"%b {dt.day}, %Y")
+            except Exception:
+                status_since = issue_dt_str[:10]
+
+        description_issue = event.get('DescriptionIssue', '')
+        event_type_id = event_type.get('Id', 0)
+        status_label = STATUS_LABEL.get(event_type_id, site['beachStatus'])
+
+        site['StatusSince'] = status_since
+        site['StatusNote'] = description_issue or (f"{status_label} since {status_since}" if status_since else status_label)
+
+        if site['beachStatus'] == 'Advisory':
+            site['Advisory'] = description_issue or f"Advisory issued {status_since}"
+        elif site['beachStatus'] == 'Closure':
+            site['Closure'] = description_issue or f"Closure issued {status_since}"
+
+        if city_label and not site['City']:
+            site['City'] = city_label
+
+    return list(sites_by_id.values())
+
+
+def cosd_build_geodataframe(sites: list[dict]) -> gpd.GeoDataFrame:
+    """Convert the site list from cosd_get_beach_status() to a GeoDataFrame."""
+    df = pd.DataFrame(sites)
+    if df.empty:
+        return gpd.GeoDataFrame()
+
+    # Filter out sites with missing coordinates
+    valid = df[(df['Latitude'] != 0) | (df['Longitude'] != 0)].copy()
+    if valid.empty:
+        get_dagster_logger().warning("All sites have zero coordinates")
+        valid = df.copy()
+
+    gs = gpd.GeoSeries.from_xy(valid['Longitude'], valid['Latitude'])
+    gdf = gpd.GeoDataFrame(valid, geometry=gs, crs='EPSG:4326')
+
+    # Map RBGColor to Icon
+    def _rgb_to_icon(color):
+        return ICONS.get(color, ICONS.get('beach', 'place'))
+
+    gdf['Icon'] = gdf['RBGColor'].apply(_rgb_to_icon)
+    return gdf
+
+
 @asset(group_name="tijuana", key_prefix="waterquality",
        name="sdbeachinfo_status", required_resource_keys={"s3", "airtable"},
-
-       automation_condition=AutomationCondition.eager()     )
+       automation_condition=AutomationCondition.eager())
 def get_sdbeachinfo_status(context) -> gpd.GeoDataFrame:
-    '''
-    Collects the San Diego Beachinfo Notices on daily schedule
-    www.sdbeachinfo.com
-    '''
+    """
+    Collects San Diego County beach advisory/closure status from the CoSD beach info site.
+    Source: https://cosdapps.sandiegocounty.gov/sdbeachinfo/
+    (Replaced the old www.sdbeachinfo.com/Home/GetTargetByID endpoint)
+    """
     name = 'sdbeachinfo_status'
-    description = '''Collects the San Diego Beachinfo Notices on daily schedule
-         www.sdbeachinfo.com
-         The source is a json response from ASP.Net component that provides information about all San Diego County Beaches
-         adds: 
-         * text information about beachStatus based on IndicatorID
-         * text information on the Station Type based on TypeID
-         * statusNote that is a cleaned version of the (Closure/Advisory) messages
+    description = '''Collects San Diego County beach advisory and closure status.
+         Source: https://cosdapps.sandiegocounty.gov/sdbeachinfo/
+         Uses the CoSD OutSystems API to retrieve all monitoring sites with:
+         * Current status (Open / Advisory / Closure)
+         * Site location (latitude/longitude)
+         * Event details (issue date, description)
         '''
-    source_url = 'https://www.sdbeachinfo.com/Home/GetTargetByID'
+    source_url = COSD_BEACH_URL
     metadata = store_assets.objectMetadata(name=name, description=description, source_url=source_url)
     s3_resource = context.resources.s3
-    # need to pass in as optional env variable
-    # https://www.sdbeachinfo.com/Home/GetTargetByID
-    closures_page='https://www.sdbeachinfo.com/Home/GetTargetByID'
-    response = requests.post(closures_page)
-    if response.status_code != 200:
-        get_dagster_logger().error(f" get beach clousure error: {response.status_code} {response.text}")
-        raise  Exception (response.text)
-    else:
-        try:
-            data = response.json()
-            closures_df = pd.DataFrame(data)
-            # gs = gpd.GeoSeries.from_xy(closures_df['Longitude'], closures_df['Latitude'])
-            # closures_gdf = gpd.GeoDataFrame(closures_df, geometry=gs, crs='EPSG:4326')
-            # closures_gdf['Icon'] = 'place'
-            # closures_gdf['RBGColor'] = closures_gdf['RBGColor'].map(lambda x: x.strip().replace('.png', ''))
 
+    try:
+        sites = cosd_get_beach_status()
+    except Exception as e:
+        get_dagster_logger().error(f"Failed to fetch CoSD beach status: {e}")
+        raise
 
-        except Exception as e:
-            get_dagster_logger().error(f" get beach clousure parsing response: {e}")
-            return gpd.GeoDataFrame()
-    closures_gdf= sdbeachinfo_clean_data(closures_df)
-    closures_gdf= closures_gdf[['SiteID','DehID','Name','Latitude','Longitude', 'IndicatorID', 'Active','RBGColor', 'Icon',
-                                    'Description', 'Advisory',	'Closure',
-                                    'beachStatus','LocationType', 'StatusSince', 'StatusNote', 'geometry'
-                                    ]]
+    if not sites:
+        get_dagster_logger().warning("CoSD beach status returned no sites")
+        return gpd.GeoDataFrame()
+
+    closures_gdf = cosd_build_geodataframe(sites)
+    get_dagster_logger().info(f"CoSD beach status: {len(closures_gdf)} sites total")
+    get_dagster_logger().info(f"  Advisory: {(closures_gdf['beachStatus']=='Advisory').sum()}")
+    get_dagster_logger().info(f"  Closure: {(closures_gdf['beachStatus']=='Closure').sum()}")
+    get_dagster_logger().info(f"  Open: {(closures_gdf['beachStatus']=='Open').sum()}")
+
+    output_cols = ['SiteID', 'DehID', 'Name', 'BeachName', 'City', 'Region',
+                   'Latitude', 'Longitude', 'IndicatorID', 'Active', 'RBGColor', 'Icon',
+                   'Description', 'Advisory', 'Closure',
+                   'beachStatus', 'LocationType', 'StatusSince', 'StatusNote', 'geometry']
+    available_cols = [c for c in output_cols if c in closures_gdf.columns]
+    closures_gdf = closures_gdf[available_cols]
+
     filename = f'{s3_output_path}/output/current/sdbeachinfo_status'
-    store_assets.geodataframe_to_s3(closures_gdf, filename, s3_resource, formats=['json','csv','geojson'], metadata=metadata)
-    # just name, location
-   # closures_name_df= closures_gdf[['SiteID','DehID','Name','Latitude','Longitude', 'IndicatorID', 'Active','RBGColor', 'Icon',
-     #                               'Description', 'Advisory',	'Closure',
-      #                               'beachStatus','LocationType', 'StatusSince', 'StatusNote'
-      #                              ]]
-
-    #store_assets.dataframe_to_s3(closures_name_df, filename, s3_resource, formats=['json'])
+    store_assets.geodataframe_to_s3(closures_gdf, filename, s3_resource,
+                                    formats=['json', 'csv', 'geojson'], metadata=metadata)
     return closures_gdf
 
 def get_cache_s3_path(cache_key):
@@ -425,7 +614,7 @@ def beachwatch_status_translation(context, sdbeachinfo_status: gpd.GeoDataFrame)
        * Advisory_es
        * statusNote_es 
         '''
-    source_url = 'https://www.sdbeachinfo.com/Home/GetTargetByID'
+    source_url = COSD_BEACH_URL
     metadata = store_assets.objectMetadata(name=name, description=description, source_url=source_url)
     s3_resource = context.resources.s3
     openai_resource = context.resources.openai
@@ -673,14 +862,19 @@ def beachwatch__closures_year(context):
 
 
 def fetch_last_updated():
-    """Fetch the 'Last Updated' timestamp from the website."""
-    url = "https://www.sdbeachinfo.com/"
-    response = requests.get(url)
-    response.raise_for_status()
-    soup = BeautifulSoup(response.text, "html.parser")
-    last_updated_div = soup.find("div", string=lambda text: text and "Last Updated:" in text)
-    if last_updated_div:
-        return last_updated_div.text.strip()
+    """Fetch the 'Last Updated' timestamp from the CoSD beach info site."""
+    import warnings
+    import urllib3
+    warnings.filterwarnings('ignore', category=urllib3.exceptions.InsecureRequestWarning)
+    response = requests.get(
+        f"{COSD_BEACH_URL}screenservices/CoSD_Beach_Water_CW/MainFlow/HomeBlockNew/DataActionGetLastDateTime",
+        verify=False, timeout=15
+    )
+    # Endpoint requires OutSystems session; fall back to full URL
+    # The moduleversioninfo endpoint is public and always available
+    mv_resp = requests.get(f"{COSD_BEACH_URL}moduleservices/moduleversioninfo", verify=False, timeout=15)
+    if mv_resp.status_code == 200:
+        return mv_resp.json().get('versionToken', '')
     return None
 
 

--- a/workflows/tijuana/src/tijuana/assets/beach_monitoring.py
+++ b/workflows/tijuana/src/tijuana/assets/beach_monitoring.py
@@ -497,6 +497,126 @@ def get_sdbeachinfo_status(context) -> gpd.GeoDataFrame:
                                     formats=['json', 'csv', 'geojson'], metadata=metadata)
     return closures_gdf
 
+
+@asset(
+    group_name="tijuana",
+    key_prefix="waterquality",
+    name="beach_site_id_mapping",
+    required_resource_keys={"s3"},
+    automation_condition=AutomationCondition.eager(),
+    ins={
+        "sdbeachinfo_status": AssetIn(key=AssetKey(["waterquality", "sdbeachinfo_status"])),
+    },
+    description=(
+        "Cross-reference between CoSD beach monitoring numeric site IDs and "
+        "California state beachwatch Station_IDs (letter-number format). "
+        "Matched by nearest-neighbor spatial join."
+    ),
+)
+def beach_site_id_mapping(context, sdbeachinfo_status: gpd.GeoDataFrame) -> pd.DataFrame:
+    """
+    Produces a mapping table linking CoSD numeric site IDs to CA state
+    beachwatch Station_IDs.  Both systems cover the same San Diego beaches
+    but use incompatible identifiers, making this table the join key for
+    cross-referencing advisory/closure histories from the state dataset
+    against CoSD site descriptions and locations.
+
+    Matching strategy: nearest-neighbor spatial join (projected to UTM 11N
+    for accurate metre distances). Rows with match_distance_m > 500 should
+    be reviewed — they likely indicate sites with no direct counterpart.
+    """
+    s3_resource = context.resources.s3
+
+    # --- CoSD sites (already fetched upstream) ---
+    cosd_gdf = sdbeachinfo_status.copy()
+    if cosd_gdf.empty:
+        get_dagster_logger().warning("beach_site_id_mapping: sdbeachinfo_status is empty, skipping")
+        return pd.DataFrame()
+
+    cosd_keep = [c for c in ['SiteID', 'Name', 'BeachName', 'City', 'Description', 'geometry'] if c in cosd_gdf.columns]
+    cosd_gdf = cosd_gdf[cosd_keep]
+
+    # --- CA state beachwatch stations ---
+    # Use a year with dense data; blank year returns all years (slow) so use current.
+    current_year = datetime.date.today().year
+    get_data = {**formdata, 'year': current_year}
+    try:
+        bw_raw = get_beachwatch_data(reports_page, exports_page, get_data)
+    except Exception as e:
+        get_dagster_logger().warning(f"beach_site_id_mapping: beachwatch fetch failed ({e}), skipping")
+        return pd.DataFrame()
+
+    if bw_raw.empty:
+        get_dagster_logger().warning("beach_site_id_mapping: no beachwatch data returned")
+        return pd.DataFrame()
+
+    get_dagster_logger().info(f"beach_site_id_mapping: beachwatch columns: {list(bw_raw.columns)}")
+
+    # Station_ID is the state letter-number ID (e.g. 'B-061'); keep it and the name/location cols.
+    name_col = next((c for c in ['StationName', 'Station_Name', 'BeachName', 'Beach_Name', 'Name'] if c in bw_raw.columns), None)
+    required = ['Station_ID', 'Latitude', 'Longitude']
+    if not all(c in bw_raw.columns for c in required):
+        get_dagster_logger().warning(f"beach_site_id_mapping: missing required columns {required} in beachwatch data")
+        return pd.DataFrame()
+
+    keep = required + ([name_col] if name_col else [])
+    stations = (
+        bw_raw[keep]
+        .drop_duplicates(subset=['Station_ID'])
+        .assign(
+            Latitude=lambda d: pd.to_numeric(d['Latitude'], errors='coerce'),
+            Longitude=lambda d: pd.to_numeric(d['Longitude'], errors='coerce'),
+        )
+        .dropna(subset=['Latitude', 'Longitude'])
+    )
+
+    bw_gdf = gpd.GeoDataFrame(
+        stations,
+        geometry=gpd.points_from_xy(stations['Longitude'], stations['Latitude']),
+        crs='EPSG:4326',
+    )
+
+    # --- Spatial nearest-neighbor join (UTM zone 11N for metre distances) ---
+    cosd_proj = cosd_gdf.to_crs('EPSG:32611')
+    bw_proj = bw_gdf.to_crs('EPSG:32611')
+
+    joined = gpd.sjoin_nearest(cosd_proj, bw_proj, how='left', distance_col='match_distance_m')
+
+    rename = {'SiteID': 'cosd_id', 'Name': 'cosd_name', 'BeachName': 'cosd_beach_name',
+              'City': 'cosd_city', 'Description': 'cosd_description',
+              'Station_ID': 'bw_station_id'}
+    if name_col:
+        rename[name_col] = 'bw_station_name'
+
+    out_cols = [c for c in list(rename.keys()) + ['match_distance_m'] if c in joined.columns]
+    mapping = joined[out_cols].copy().rename(columns=rename)
+    mapping['match_distance_m'] = mapping['match_distance_m'].round(1)
+    mapping['match_quality'] = mapping['match_distance_m'].apply(
+        lambda d: 'good' if d < 200 else ('ok' if d < 500 else 'poor')
+    )
+
+    good = (mapping['match_quality'] == 'good').sum()
+    ok = (mapping['match_quality'] == 'ok').sum()
+    poor = (mapping['match_quality'] == 'poor').sum()
+    get_dagster_logger().info(
+        f"beach_site_id_mapping: {len(mapping)} CoSD sites — "
+        f"{good} good (<200 m), {ok} ok (<500 m), {poor} poor (>500 m)"
+    )
+
+    name = 'beach_site_id_mapping'
+    description = (
+        "Cross-reference between CoSD beach monitoring site IDs (numeric) and "
+        "CA state beachwatch Station_IDs (letter-number). Matched by nearest-neighbor "
+        "spatial join. match_distance_m is the distance in metres between the two points; "
+        "rows with match_quality='poor' (>500 m) should be reviewed manually."
+    )
+    metadata = store_assets.objectMetadata(name=name, description=description, source_url=COSD_BEACH_URL)
+    filename = f'{s3_output_path}/output/reference/beach_site_id_mapping'
+    store_assets.dataframe_to_s3(mapping, filename, s3_resource, metadata=metadata)
+
+    return mapping
+
+
 def get_cache_s3_path(cache_key):
     """Get the S3 path for a translation cache entry"""
     return f'{s3_output_path}/cache/translations/{cache_key}.json'

--- a/workflows/tijuana/src/tijuana/assets/beach_monitoring.py
+++ b/workflows/tijuana/src/tijuana/assets/beach_monitoring.py
@@ -1013,16 +1013,12 @@ def beachwatch__closures_year(context):
 
 
 def fetch_last_updated():
-    """Fetch the 'Last Updated' timestamp from the CoSD beach info site."""
+    """Return the CoSD module version token, used as a change-detection cursor."""
     import warnings
     import urllib3
     warnings.filterwarnings('ignore', category=urllib3.exceptions.InsecureRequestWarning)
-    response = requests.get(
-        f"{COSD_BEACH_URL}screenservices/CoSD_Beach_Water_CW/MainFlow/HomeBlockNew/DataActionGetLastDateTime",
-        verify=False, timeout=15
-    )
-    # Endpoint requires OutSystems session; fall back to full URL
-    # The moduleversioninfo endpoint is public and always available
+    # moduleservices/moduleversioninfo is a public GET endpoint; the screenservices
+    # data-action endpoints require a POST with session auth, so we don't touch them here.
     mv_resp = requests.get(f"{COSD_BEACH_URL}moduleservices/moduleversioninfo", verify=False, timeout=15)
     if mv_resp.status_code == 200:
         return mv_resp.json().get('versionToken', '')

--- a/workflows/tijuana/src/tijuana/assets/beach_monitoring.py
+++ b/workflows/tijuana/src/tijuana/assets/beach_monitoring.py
@@ -43,12 +43,14 @@ COSD_BLOCK_MARKUP = "screenservices/CoSD_Beach_Water_CW/MainFlow/BlockMarkup"
 # EventTypeId values from the CoSD API
 COSD_EVENT_TYPE_ADVISORY = 1
 COSD_EVENT_TYPE_CLOSURE = 2
+COSD_EVENT_TYPE_WARNING = 3
 
 # Map CoSD EventTypeId to old IndicatorID (for backward compatibility)
 COSD_EVENT_TYPE_TO_INDICATOR = {
     COSD_EVENT_TYPE_CLOSURE: 1,   # Closure → IndicatorID 1
-    2: 2,                          # Open (no event) → IndicatorID 2
+    0: 2,                          # Open (no event) → IndicatorID 2
     COSD_EVENT_TYPE_ADVISORY: 3,  # Advisory → IndicatorID 3
+    COSD_EVENT_TYPE_WARNING: 4,   # Warning → IndicatorID 4
 }
 
 STATUS_COLOR = {
@@ -61,6 +63,7 @@ STATUS_COLOR = {
 STATUS_LABEL = {
     COSD_EVENT_TYPE_ADVISORY: 'Advisory',
     COSD_EVENT_TYPE_CLOSURE: 'Closure',
+    COSD_EVENT_TYPE_WARNING: 'Warning',
 }
 
 formdata={
@@ -195,6 +198,7 @@ def cosd_get_beach_status() -> list[dict]:
     sites_by_id = {}
     advisory_ids = set()
     closure_ids = set()
+    warning_ids = set()
     event_details = {}
     captured_api_versions = {}
 
@@ -347,8 +351,33 @@ def cosd_get_beach_status() -> list[dict]:
                     'StatusSince': '', 'StatusNote': '', 'LocationType': 'Monitoring Point',
                 }
 
-        # Step 4: Get event details (issue date, description) for affected sites
-        affected_ids = advisory_ids | closure_ids
+        # Step 4: Mark warning sites (EventTypeId=3)
+        warning_items = call_get_site_by_id(COSD_EVENT_TYPE_WARNING)
+        get_dagster_logger().info(f"CoSD: {len(warning_items)} warning sites")
+        for item in warning_items:
+            site_id = item.get('Id', '')
+            warning_ids.add(site_id)
+            if site_id in sites_by_id:
+                # Only downgrade to Warning if not already Closure or Advisory
+                if sites_by_id[site_id]['beachStatus'] == 'Open':
+                    sites_by_id[site_id]['beachStatus'] = 'Warning'
+                    sites_by_id[site_id]['IndicatorID'] = 4
+                    sites_by_id[site_id]['RBGColor'] = 'Yellow'
+            else:
+                sites_by_id[site_id] = {
+                    'SiteID': site_id, 'DehID': site_id,
+                    'Name': item.get('LocationName', ''), 'BeachName': item.get('BeachName', ''),
+                    'City': item.get('City', ''), 'Region': item.get('Region', ''),
+                    'Latitude': float(item.get('Latitude', 0) or 0),
+                    'Longitude': float(item.get('Longitude', 0) or 0),
+                    'Description': item.get('Description', ''),
+                    'beachStatus': 'Warning', 'IndicatorID': 4, 'Active': True,
+                    'RBGColor': 'Yellow', 'Advisory': '', 'Closure': '',
+                    'StatusSince': '', 'StatusNote': '', 'LocationType': 'Monitoring Point',
+                }
+
+        # Step 5: Get event details (issue date, description) for affected sites
+        affected_ids = advisory_ids | closure_ids | warning_ids
         get_dagster_logger().info(f"CoSD: fetching event details for {len(affected_ids)} affected sites")
         for site_id in affected_ids:
             events = call_get_events_list(site_id)
@@ -357,7 +386,7 @@ def cosd_get_beach_status() -> list[dict]:
 
         browser.close()
 
-    # Step 5: Merge event details into site records
+    # Step 6: Merge event details into site records
     for site_id, event_item in event_details.items():
         if site_id not in sites_by_id:
             continue
@@ -387,6 +416,8 @@ def cosd_get_beach_status() -> list[dict]:
             site['Advisory'] = description_issue or f"Advisory issued {status_since}"
         elif site['beachStatus'] == 'Closure':
             site['Closure'] = description_issue or f"Closure issued {status_since}"
+        elif site['beachStatus'] == 'Warning':
+            site['Advisory'] = description_issue or f"Warning issued {status_since}"
 
         if city_label and not site['City']:
             site['City'] = city_label


### PR DESCRIPTION
## Summary

- **Replaces dead sdbeachinfo.com API** with the new `cosdapps.sandiegocounty.gov/sdbeachinfo/` OutSystems app. The old site redirected and its `POST /Home/GetTargetByID` endpoint now returns 405.
- **Uses Playwright** to initialize the OutSystems session (JS cookies + CSRF token), intercept dynamic `apiVersion` values at page load, then call `GetSiteById` and `GetEventsList` via in-browser `fetch()`.
- **Fetches all 89 monitoring sites** with coordinates, descriptions, and current status (Open / Advisory / Warning / Closure). Warning (yellow) is a new third alert level alongside Advisory (orange) and Closure (red).
- **Adds `beach_site_id_mapping` asset** — nearest-neighbor spatial join (UTM 11N) between CoSD numeric site IDs and CA state beachwatch `Station_ID` letter-number codes, enabling cross-referencing of state closure/advisory history against CoSD site descriptions.
- **Fixes `fetch_last_updated()`** — removed a dead GET to a POST-only screenservices endpoint that returned 405 on every sensor tick.
- **Adds `'Orange': 'beach'` to `ICONS`** (resilient_core) so advisory sites render correctly on the map.

## Test plan

- [ ] Checkout branch and run `playwright install chromium --with-deps` if not already installed
- [ ] `dagster asset materialize --select waterquality/sdbeachinfo_status -m tijuana` — confirm ~89 sites, correct closure/advisory counts in logs
- [ ] `dagster asset materialize --select waterquality/beach_site_id_mapping -m tijuana` — confirm mapping CSV written to S3
- [ ] `dagster asset materialize --select waterquality/sdbeachinfo_status_translation -m tijuana` — confirm Spanish translation runs downstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3WdqLLqWZoAWNdKjKqRLm

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3WdqLLqWZoAWNdKjKqRLm)_