### PR TITLE
Add VectorSurv vector-borne disease surveillance assets

### DIFF
--- a/prototypes/vectorsurv/README.md
+++ b/prototypes/vectorsurv/README.md
@@ -1,0 +1,39 @@
+# VectorSurv prototypes — California / San Diego
+
+Standalone prototype pages for the VectorSurv (maps.vectorsurv.org) vector-borne
+surveillance data that the `pathogens` code location now ingests weekly
+(`workflows/pathogens/src/pathogens/assets/vectorsurv.py`).
+
+| Page | Layers | Detail on click |
+|------|--------|-----------------|
+| `dengue_invasive.html` | Invasive *Aedes* surveillance regions and dengue transmission-risk regions (subcounty polygons) | Species detection summary + weekly mosquito counts chart (2010–present); weekly dengue risk-index chart |
+| `arbovirus.html` | Arbovirus activity (WNV, SLEV, WEEV, …): positive mosquito pools, dead birds, sentinel seroconversions by city | Positives-by-year stacked chart and top-cities table |
+
+Both default to a **San Diego** view with an **All California** toggle.
+
+## Running
+
+The pages are self-contained (Leaflet from CDN) and read the public VectorSurv
+map API (`https://mathew.vectorsurv.org/v2`, CORS-enabled) directly, decoding
+the encoded-polyline geometries client-side. Serve the directory and open a
+page:
+
+```bash
+cd prototypes/vectorsurv
+python3 -m http.server 8080
+# http://localhost:8080/dengue_invasive.html
+# http://localhost:8080/arbovirus.html
+```
+
+`?api=<base-url>` overrides the API base, e.g. to point at a mirror of the raw
+payloads stored by the Dagster assets under
+`pathogens/vectorborne/raw/vectorsurv/` in S3.
+
+## Data notes
+
+* Weekly invasive counts: weeks without surveillance are omitted by the API;
+  `0` means surveyed with none collected.
+* The dengue risk index is a weekly modeled transmission-risk value (0 = no
+  risk).
+* The mosquito-abundance (AMoR) endpoints of the same API require a VectorSurv
+  Gateway login and are not used here.

--- a/prototypes/vectorsurv/arbovirus.html
+++ b/prototypes/vectorsurv/arbovirus.html
@@ -1,0 +1,353 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Arbovirus Activity — VectorSurv prototype</title>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<style>
+  :root {
+    color-scheme: light;
+    --surface-1: #fcfcfb;
+    --page: #f9f9f7;
+    --text-primary: #0b0b0b;
+    --text-secondary: #52514e;
+    --text-muted: #898781;
+    --grid: #e1e0d9;
+    --baseline: #c3c2b7;
+    --border: rgba(11,11,11,0.10);
+    --series-1: #2a78d6;   /* positive mosquito pools */
+    --series-2: #eb6834;   /* dead birds */
+    --series-3: #1baf7a;   /* sentinel seroconversions */
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      color-scheme: dark;
+      --surface-1: #1a1a19;
+      --page: #0d0d0d;
+      --text-primary: #ffffff;
+      --text-secondary: #c3c2b7;
+      --text-muted: #898781;
+      --grid: #2c2c2a;
+      --baseline: #383835;
+      --border: rgba(255,255,255,0.10);
+      --series-1: #3987e5;
+      --series-2: #d95926;
+      --series-3: #199e70;
+    }
+    .leaflet-tile { filter: grayscale(0.3) brightness(0.7); }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--page); color: var(--text-primary);
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif; font-size: 14px;
+  }
+  header { padding: 14px 18px 6px; }
+  header h1 { margin: 0; font-size: 18px; }
+  header p { margin: 4px 0 0; color: var(--text-secondary); max-width: 72em; }
+  .controls { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; padding: 10px 18px; }
+  .controls .group {
+    display: flex; gap: 6px; align-items: center; background: var(--surface-1);
+    border: 1px solid var(--border); border-radius: 8px; padding: 4px 8px;
+  }
+  .controls label { color: var(--text-secondary); }
+  .controls select { font: inherit; }
+  .seg { display: inline-flex; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+  .seg button { font: inherit; border: 0; background: var(--surface-1); color: var(--text-secondary); padding: 5px 12px; cursor: pointer; }
+  .seg button.active { background: var(--series-1); color: #fff; }
+  .layout { display: flex; gap: 12px; padding: 0 18px 18px; height: calc(100vh - 150px); min-height: 500px; }
+  #map { flex: 2 1 58%; border-radius: 10px; border: 1px solid var(--border); min-width: 0; }
+  aside {
+    flex: 1 1 34%; min-width: 320px; max-width: 480px; overflow-y: auto;
+    background: var(--surface-1); border: 1px solid var(--border); border-radius: 10px; padding: 14px;
+  }
+  aside h2 { margin: 0 0 2px; font-size: 15px; }
+  aside .sub { color: var(--text-muted); margin: 0 0 8px; }
+  .chart-legend { display: flex; flex-wrap: wrap; gap: 12px; margin: 6px 0; color: var(--text-secondary); font-size: 12px; }
+  .chart-legend .row { display: flex; gap: 5px; align-items: center; }
+  .chart-legend .chip { width: 10px; height: 10px; border-radius: 3px; }
+  table { border-collapse: collapse; width: 100%; margin-top: 8px; font-size: 13px; }
+  th, td { text-align: left; padding: 3px 6px; border-bottom: 1px solid var(--grid); }
+  th { color: var(--text-muted); font-weight: 500; }
+  td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+  .status { color: var(--text-muted); padding: 2px 18px 8px; }
+  .footer-note { color: var(--text-muted); font-size: 12px; padding: 0 18px 14px; }
+  #tooltip {
+    position: fixed; pointer-events: none; display: none; z-index: 2000;
+    background: var(--surface-1); border: 1px solid var(--border); border-radius: 8px;
+    padding: 6px 9px; box-shadow: 0 2px 10px rgba(0,0,0,0.18); font-size: 12px;
+  }
+  a { color: var(--series-1); }
+</style>
+</head>
+<body>
+<header>
+  <h1>Arbovirus Surveillance Activity — California / San Diego</h1>
+  <p>Prototype of the data behind
+    <a href="https://maps.vectorsurv.org/arbo" target="_blank" rel="noopener">maps.vectorsurv.org/arbo</a>:
+    positive mosquito pools, dead birds and sentinel-chicken seroconversions by city and month,
+    2003–present. Marker area scales with the number of positives for the current filters.</p>
+</header>
+
+<div class="controls">
+  <span class="group">
+    <label for="pathogenSel">Pathogen</label>
+    <select id="pathogenSel"></select>
+  </span>
+  <span class="group">
+    <label for="yearSel">Year</label>
+    <select id="yearSel"><option value="all" selected>All years</option></select>
+  </span>
+  <span class="seg" id="scopeSeg">
+    <button data-scope="sd" class="active">San Diego region</button>
+    <button data-scope="ca">All California</button>
+  </span>
+</div>
+<div class="status" id="status">Loading VectorSurv arbovirus data (~10 MB)…</div>
+
+<div class="layout">
+  <div id="map"></div>
+  <aside>
+    <h2 id="panelTitle">Statewide summary</h2>
+    <p class="sub" id="panelSub"></p>
+    <div class="chart-legend" id="legend"></div>
+    <div id="chart"></div>
+    <div id="tableWrap"></div>
+  </aside>
+</div>
+<p class="footer-note">
+  Source: VectorSurv Gateway public map API (<code>mathew.vectorsurv.org/v2/arbo/</code>) —
+  UC Davis / CDPH / MVCAC. “San Diego region” filters points to the San Diego County
+  bounding box (32.5–33.51&nbsp;N, 118.2–116.15&nbsp;W). A “record” is one reported positive
+  collection (pool, bird or seroconversion event) in that city-month.
+</p>
+<div id="tooltip"></div>
+
+<script>
+const API = new URLSearchParams(location.search).get('api') || 'https://mathew.vectorsurv.org/v2';
+// San Diego County bounding box (33.51 N keeps out southern Riverside County
+// cities; -116.15 W keeps out the Salton Sea communities in Imperial/Riverside).
+const SD_BBOX = { minLat: 32.5, maxLat: 33.51, minLon: -118.2, maxLon: -116.15 };
+
+// layer key -> [pathogen, indicator]
+const LAYERS = {
+  WNVPools: ['West Nile virus', 'pools'], WNVBirds: ['West Nile virus', 'birds'],
+  WNVSentinels: ['West Nile virus', 'sentinels'],
+  SLEVPools: ['St. Louis encephalitis virus', 'pools'],
+  SLEVSentinels: ['St. Louis encephalitis virus', 'sentinels'],
+  WEEVPools: ['Western equine encephalitis virus', 'pools'],
+  WEEVSentinels: ['Western equine encephalitis virus', 'sentinels'],
+  CVVPools: ['Cache Valley virus', 'pools'], LACVPools: ['La Crosse virus', 'pools'],
+  JCVPools: ['Jamestown Canyon virus', 'pools'], EEEVPools: ['Eastern equine encephalitis virus', 'pools'],
+  FLAVPools: ['Flanders virus', 'pools'],
+};
+const INDICATORS = {
+  pools:     { label: 'Positive mosquito pools', varName: '--series-1' },
+  birds:     { label: 'Dead birds',              varName: '--series-2' },
+  sentinels: { label: 'Sentinel seroconversions', varName: '--series-3' },
+};
+const MONTHS = { Jan:1, Feb:2, Mar:3, Apr:4, May:5, Jun:6, Jul:7, Aug:8, Sep:9, Oct:10, Nov:11, Dec:12 };
+const css = name => getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+
+const state = { rows: [], pathogen: 'West Nile virus', year: 'all', scope: 'sd', markers: null };
+
+const map = L.map('map', { zoomSnap: 0.5 }).setView([32.9, -116.9], 9);
+L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+  attribution: '&copy; OpenStreetMap contributors &copy; CARTO', maxZoom: 18
+}).addTo(map);
+
+async function loadAll() {
+  const status = document.getElementById('status');
+  try {
+    const payload = await fetch(`${API}/arbo/`).then(r => r.json());
+    const rows = [];
+    for (const [layer, fc] of Object.entries(payload)) {
+      const [pathogen, indicator] = LAYERS[layer] || [layer, 'pools'];
+      for (const f of fc.features || []) {
+        const p = f.properties || {};
+        if (p.state !== 'CA') continue;
+        const [lon, lat] = f.geometry.coordinates;
+        const monthly = new Map();
+        for (const entry of p.collections || []) {
+          for (const [label, value] of Object.entries(entry)) {
+            const [mon, year] = label.split(' ');
+            if (!MONTHS[mon]) continue;
+            const key = `${year}-${String(MONTHS[mon]).padStart(2, '0')}`;
+            const bucket = monthly.get(key) || { count: 0, records: 0 };
+            bucket.count += value || 0; bucket.records += 1;
+            monthly.set(key, bucket);
+          }
+        }
+        for (const [ym, bucket] of monthly) {
+          rows.push({ pathogen, indicator, city: p.city, lat, lon,
+                      year: +ym.slice(0, 4), month: +ym.slice(5), ym,
+                      count: bucket.count, records: bucket.records });
+        }
+      }
+    }
+    state.rows = rows;
+    initControls();
+    status.textContent = `${rows.length.toLocaleString()} California city-month records, ` +
+      `${Math.min(...rows.map(r => r.year))}–${Math.max(...rows.map(r => r.year))}.`;
+    render();
+  } catch (e) {
+    status.textContent = `Failed to load VectorSurv data: ${e}`;
+  }
+}
+
+function initControls() {
+  const pathogens = [...new Set(state.rows.map(r => r.pathogen))];
+  // WNV first, then by total count descending
+  const totals = Object.fromEntries(pathogens.map(p =>
+    [p, state.rows.filter(r => r.pathogen === p).reduce((s, r) => s + r.count, 0)]));
+  pathogens.sort((a, b) => totals[b] - totals[a]);
+  document.getElementById('pathogenSel').innerHTML =
+    pathogens.map(p => `<option ${p === state.pathogen ? 'selected' : ''}>${p}</option>`).join('');
+  const years = [...new Set(state.rows.map(r => r.year))].sort((a, b) => b - a);
+  document.getElementById('yearSel').innerHTML =
+    `<option value="all" selected>All years</option>` + years.map(y => `<option>${y}</option>`).join('');
+}
+
+function filtered() {
+  return state.rows.filter(r =>
+    r.pathogen === state.pathogen &&
+    (state.year === 'all' || r.year === +state.year) &&
+    (state.scope === 'ca' ||
+      (r.lat >= SD_BBOX.minLat && r.lat <= SD_BBOX.maxLat && r.lon >= SD_BBOX.minLon && r.lon <= SD_BBOX.maxLon)));
+}
+
+function render() {
+  const rows = filtered();
+  if (state.markers) { map.removeLayer(state.markers); state.markers = null; }
+  const group = L.featureGroup();
+
+  // aggregate per city+indicator for the map
+  const byCity = new Map();
+  for (const r of rows) {
+    const key = `${r.city}|${r.indicator}`;
+    const cur = byCity.get(key) || { ...r, count: 0, records: 0 };
+    cur.count += r.count; cur.records += r.records;
+    byCity.set(key, cur);
+  }
+  const values = [...byCity.values()];
+  const maxCount = Math.max(1, ...values.map(v => v.count));
+  for (const v of values.sort((a, b) => b.count - a.count)) {
+    const color = css(INDICATORS[v.indicator].varName);
+    const radius = 5 + 22 * Math.sqrt(v.count / maxCount);
+    const marker = L.circleMarker([v.lat, v.lon], {
+      radius, color, weight: 1.5, fillColor: color, fillOpacity: 0.45,
+    });
+    marker.bindTooltip(
+      `<b>${v.city}</b><br>${INDICATORS[v.indicator].label}: ${v.count}` +
+      (state.year === 'all' ? ' (all years)' : ` (${state.year})`), { sticky: true });
+    marker.addTo(group);
+  }
+  state.markers = group.addTo(map);
+  if (values.length) map.fitBounds(group.getBounds().pad(0.15));
+
+  document.getElementById('legend').innerHTML = Object.values(INDICATORS).map(ind =>
+    `<span class="row"><span class="chip" style="background:${css(ind.varName)}"></span>${ind.label}</span>`).join('');
+
+  document.getElementById('panelTitle').textContent =
+    state.scope === 'sd' ? 'San Diego region summary' : 'California summary';
+  document.getElementById('panelSub').textContent =
+    `${state.pathogen} · ${state.year === 'all' ? 'all years' : state.year}`;
+  drawYearChart(rows);
+  drawTopTable(values);
+}
+
+// yearly stacked-by-indicator bar chart (2px gaps, baseline, hover tooltip)
+function drawYearChart(rows) {
+  const el = document.getElementById('chart');
+  if (!rows.length) { el.innerHTML = '<p class="sub">No records for this selection.</p>'; return; }
+  const byYear = new Map();
+  for (const r of rows) {
+    const cur = byYear.get(r.year) || { pools: 0, birds: 0, sentinels: 0 };
+    cur[r.indicator] += r.count;
+    byYear.set(r.year, cur);
+  }
+  const years = [...byYear.keys()].sort((a, b) => a - b);
+  const yMin = years[0], yMax = years[years.length - 1];
+  const allYears = []; for (let y = yMin; y <= yMax; y++) allYears.push(y);
+  const W = Math.max(el.clientWidth || 400, 320), H = 180;
+  const m = { top: 8, right: 6, bottom: 20, left: 40 };
+  const maxTotal = Math.max(...allYears.map(y => {
+    const v = byYear.get(y); return v ? v.pools + v.birds + v.sentinels : 0;
+  }), 1);
+  const bw = Math.max(2, (W - m.left - m.right) / allYears.length - 2);
+  const X = i => m.left + (W - m.left - m.right) * i / allYears.length;
+  const Y = v => m.top + (H - m.top - m.bottom) * (1 - v / maxTotal);
+  let grid = '';
+  for (let i = 0; i <= 4; i++) {
+    const v = maxTotal * i / 4, y = Y(v);
+    grid += `<line x1="${m.left}" x2="${W - m.right}" y1="${y}" y2="${y}" stroke="${css('--grid')}"/>` +
+            `<text x="${m.left - 5}" y="${y + 3}" text-anchor="end" font-size="10" fill="${css('--text-muted')}">${Math.round(v)}</text>`;
+  }
+  let bars = '';
+  allYears.forEach((year, i) => {
+    const v = byYear.get(year); if (!v) return;
+    let acc = 0;
+    for (const ind of ['pools', 'birds', 'sentinels']) {
+      if (!v[ind]) continue;
+      const y1 = Y(acc), y0 = Y(acc + v[ind]);
+      bars += `<rect data-year="${year}" x="${X(i).toFixed(1)}" y="${y0.toFixed(1)}" width="${bw.toFixed(1)}" ` +
+              `height="${Math.max(1, y1 - y0 - (acc ? 2 : 0)).toFixed(1)}" rx="2" fill="${css(INDICATORS[ind].varName)}"/>`;
+      acc += v[ind];
+    }
+  });
+  let xlabels = '';
+  const step = Math.max(1, Math.ceil(allYears.length / 6));
+  for (let i = 0; i < allYears.length; i += step)
+    xlabels += `<text x="${X(i)}" y="${H - 5}" font-size="10" fill="${css('--text-muted')}">${allYears[i]}</text>`;
+  el.innerHTML = `
+    <div style="font-weight:600">Positives by year</div>
+    <svg viewBox="0 0 ${W} ${H}" width="100%" role="img" aria-label="Positives by year">
+      ${grid}
+      <line x1="${m.left}" x2="${W - m.right}" y1="${Y(0)}" y2="${Y(0)}" stroke="${css('--baseline')}"/>
+      ${bars}${xlabels}
+    </svg>`;
+  const tip = document.getElementById('tooltip');
+  el.querySelectorAll('rect[data-year]').forEach(rect => {
+    rect.addEventListener('mousemove', ev => {
+      const year = +rect.dataset.year, v = byYear.get(year);
+      tip.style.display = 'block';
+      tip.style.left = (ev.clientX + 14) + 'px'; tip.style.top = (ev.clientY + 10) + 'px';
+      tip.innerHTML = `<div><b>${year}</b></div>` + Object.entries(INDICATORS)
+        .filter(([k]) => v[k]).map(([k, ind]) =>
+          `<div><span style="display:inline-block;width:9px;height:9px;border-radius:3px;background:${css(ind.varName)}"></span> ${ind.label}: <b>${v[k]}</b></div>`).join('');
+    });
+    rect.addEventListener('mouseleave', () => tip.style.display = 'none');
+  });
+}
+
+function drawTopTable(values) {
+  const byCity = new Map();
+  for (const v of values) {
+    const cur = byCity.get(v.city) || { city: v.city, pools: 0, birds: 0, sentinels: 0 };
+    cur[v.indicator] += v.count;
+    byCity.set(v.city, cur);
+  }
+  const top = [...byCity.values()]
+    .sort((a, b) => (b.pools + b.birds + b.sentinels) - (a.pools + a.birds + a.sentinels))
+    .slice(0, 15);
+  document.getElementById('tableWrap').innerHTML = `
+    <table>
+      <thead><tr><th>City</th><th class="num">Pools</th><th class="num">Birds</th><th class="num">Sentinels</th></tr></thead>
+      <tbody>${top.map(r => `<tr><td>${r.city}</td><td class="num">${r.pools || ''}</td>
+        <td class="num">${r.birds || ''}</td><td class="num">${r.sentinels || ''}</td></tr>`).join('')}</tbody>
+    </table>`;
+}
+
+document.getElementById('pathogenSel').addEventListener('change', e => { state.pathogen = e.target.value; render(); });
+document.getElementById('yearSel').addEventListener('change', e => { state.year = e.target.value; render(); });
+document.getElementById('scopeSeg').addEventListener('click', e => {
+  const btn = e.target.closest('button'); if (!btn) return;
+  document.querySelectorAll('#scopeSeg button').forEach(b => b.classList.toggle('active', b === btn));
+  state.scope = btn.dataset.scope; render();
+});
+
+loadAll();
+</script>
+</body>
+</html>

--- a/prototypes/vectorsurv/dengue_invasive.html
+++ b/prototypes/vectorsurv/dengue_invasive.html
@@ -1,0 +1,423 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Invasive Aedes &amp; Dengue Risk — VectorSurv prototype</title>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<style>
+  :root {
+    color-scheme: light;
+    --surface-1: #fcfcfb;
+    --page: #f9f9f7;
+    --text-primary: #0b0b0b;
+    --text-secondary: #52514e;
+    --text-muted: #898781;
+    --grid: #e1e0d9;
+    --baseline: #c3c2b7;
+    --border: rgba(11,11,11,0.10);
+    --series-1: #2a78d6;   /* invasive counts line */
+    --series-2: #eb6834;   /* notoscriptus */
+    --series-3: #1baf7a;   /* other */
+    --seq-100: #cde2fb; --seq-200: #9ec5f4; --seq-300: #6da7ec;
+    --seq-400: #3987e5; --seq-500: #256abf; --seq-650: #104281;
+    --no-data: #f0efec;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      color-scheme: dark;
+      --surface-1: #1a1a19;
+      --page: #0d0d0d;
+      --text-primary: #ffffff;
+      --text-secondary: #c3c2b7;
+      --text-muted: #898781;
+      --grid: #2c2c2a;
+      --baseline: #383835;
+      --border: rgba(255,255,255,0.10);
+      --series-1: #3987e5;
+      --series-2: #d95926;
+      --series-3: #199e70;
+      --no-data: #232322;
+    }
+    .leaflet-tile { filter: grayscale(0.3) brightness(0.7); }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--page); color: var(--text-primary);
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    font-size: 14px;
+  }
+  header { padding: 14px 18px 6px; }
+  header h1 { margin: 0; font-size: 18px; }
+  header p { margin: 4px 0 0; color: var(--text-secondary); max-width: 72em; }
+  .controls {
+    display: flex; flex-wrap: wrap; gap: 10px; align-items: center;
+    padding: 10px 18px;
+  }
+  .controls .group {
+    display: flex; gap: 4px; align-items: center;
+    background: var(--surface-1); border: 1px solid var(--border);
+    border-radius: 8px; padding: 4px 8px;
+  }
+  .controls label { color: var(--text-secondary); }
+  .controls select, .controls input[type=range] { font: inherit; }
+  .seg { display: inline-flex; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+  .seg button {
+    font: inherit; border: 0; background: var(--surface-1);
+    color: var(--text-secondary); padding: 5px 12px; cursor: pointer;
+  }
+  .seg button.active { background: var(--series-1); color: #fff; }
+  .layout { display: flex; gap: 12px; padding: 0 18px 18px; height: calc(100vh - 150px); min-height: 480px; }
+  #map { flex: 2 1 60%; border-radius: 10px; border: 1px solid var(--border); min-width: 0; }
+  aside {
+    flex: 1 1 32%; min-width: 300px; max-width: 460px; overflow-y: auto;
+    background: var(--surface-1); border: 1px solid var(--border);
+    border-radius: 10px; padding: 14px;
+  }
+  aside h2 { margin: 0 0 2px; font-size: 15px; }
+  aside .sub { color: var(--text-muted); margin: 0 0 10px; }
+  .legend { margin: 10px 0; }
+  .legend .row { display: flex; align-items: center; gap: 6px; margin: 2px 0; color: var(--text-secondary); }
+  .swatch { width: 14px; height: 14px; border-radius: 4px; border: 1px solid var(--border); flex: none; }
+  table { border-collapse: collapse; width: 100%; margin-top: 8px; }
+  th, td { text-align: left; padding: 4px 6px; border-bottom: 1px solid var(--grid); }
+  th { color: var(--text-muted); font-weight: 500; }
+  td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+  .chart-wrap { margin-top: 12px; }
+  .chart-title { font-weight: 600; margin-bottom: 2px; }
+  .chart-sub { color: var(--text-muted); margin-bottom: 6px; }
+  .chart-legend { display: flex; gap: 14px; margin: 4px 0 2px; color: var(--text-secondary); font-size: 12px; }
+  .chart-legend .row { display: flex; gap: 5px; align-items: center; }
+  .chart-legend .chip { width: 10px; height: 3px; border-radius: 2px; }
+  #tooltip {
+    position: fixed; pointer-events: none; display: none; z-index: 2000;
+    background: var(--surface-1); border: 1px solid var(--border); border-radius: 8px;
+    padding: 6px 9px; box-shadow: 0 2px 10px rgba(0,0,0,0.18); font-size: 12px;
+  }
+  #tooltip .t-date { color: var(--text-muted); }
+  .status { color: var(--text-muted); padding: 2px 18px 8px; }
+  .footer-note { color: var(--text-muted); font-size: 12px; padding: 0 18px 14px; }
+  a { color: var(--series-1); }
+</style>
+</head>
+<body>
+<header>
+  <h1>Invasive <i>Aedes</i> &amp; Dengue Transmission Risk — California / San Diego</h1>
+  <p>Prototype reading the public VectorSurv map API (the data behind
+     <a href="https://maps.vectorsurv.org/invasive" target="_blank" rel="noopener">maps.vectorsurv.org</a>).
+     Click a surveillance region for its detection history and weekly mosquito counts.</p>
+</header>
+
+<div class="controls">
+  <span class="seg" id="layerSeg">
+    <button data-layer="invasive" class="active">Invasive <i>&nbsp;Aedes</i></button>
+    <button data-layer="dengue">Dengue risk</button>
+  </span>
+  <span class="seg" id="scopeSeg">
+    <button data-scope="sd" class="active">San Diego County</button>
+    <button data-scope="ca">All California</button>
+  </span>
+  <span class="group" id="speciesGroup">
+    <label for="speciesSel">Color by</label>
+    <select id="speciesSel">
+      <option value="aegypti_detections" selected>Aedes aegypti detections</option>
+      <option value="albopictus_detections">Aedes albopictus detections</option>
+      <option value="notoscriptus_detections">Aedes notoscriptus detections</option>
+      <option value="japonicus_detections">Aedes japonicus detections</option>
+    </select>
+  </span>
+</div>
+<div class="status" id="status">Loading VectorSurv layers…</div>
+
+<div class="layout">
+  <div id="map"></div>
+  <aside id="panel">
+    <h2 id="panelTitle">Region detail</h2>
+    <p class="sub" id="panelSub">Click a region on the map.</p>
+    <div class="legend" id="legend"></div>
+    <div id="panelBody"></div>
+  </aside>
+</div>
+<p class="footer-note">
+  Source: VectorSurv Gateway public map API (<code>mathew.vectorsurv.org/v2</code>) —
+  UC Davis / CDPH / Mosquito &amp; Vector Control Association of California.
+  Geometries are decoded client-side from encoded polylines. Weeks without
+  surveillance are omitted from the weekly series; 0 means surveyed with none collected.
+</p>
+<div id="tooltip"></div>
+
+<script>
+const API = new URLSearchParams(location.search).get('api') || 'https://mathew.vectorsurv.org/v2';
+const CA_BBOX = { minLat: 32.3, maxLat: 42.1, minLon: -124.6, maxLon: -114.1 };
+const state = { layer: 'invasive', scope: 'sd', species: 'aegypti_detections',
+                invasive: null, dengue: null, mapLayer: null, selected: null };
+
+// ---- Google polyline5 decoding -> [lat, lon] rings ----
+function decodePolyline(str) {
+  const pts = []; let index = 0, lat = 0, lon = 0;
+  while (index < str.length) {
+    for (const isLon of [false, true]) {
+      let shift = 0, result = 0, b;
+      do { b = str.charCodeAt(index++) - 63; result |= (b & 0x1f) << shift; shift += 5; } while (b >= 0x20);
+      const d = (result & 1) ? ~(result >> 1) : (result >> 1);
+      if (isLon) lon += d; else lat += d;
+    }
+    pts.push([lat * 1e-5, lon * 1e-5]);
+  }
+  return pts;
+}
+function featureLatLngs(feature) {   // -> Leaflet MultiPolygon rings
+  return (feature.geometry.coordinates || []).map(poly => poly.map(ring => decodePolyline(ring.point)));
+}
+function inCalifornia(rings) {
+  const p = rings[0] && rings[0][0] && rings[0][0][0];
+  return p && p[0] >= CA_BBOX.minLat && p[0] <= CA_BBOX.maxLat && p[1] >= CA_BBOX.minLon && p[1] <= CA_BBOX.maxLon;
+}
+
+// ---- map ----
+const map = L.map('map', { zoomSnap: 0.5 }).setView([32.9, -116.7], 9);
+L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+  attribution: '&copy; OpenStreetMap contributors &copy; CARTO', maxZoom: 18
+}).addTo(map);
+
+const css = name => getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+const SEQ = () => [css('--seq-100'), css('--seq-200'), css('--seq-300'), css('--seq-400'), css('--seq-500'), css('--seq-650')];
+
+function seqColor(value, breaks) {
+  const ramp = SEQ();
+  if (value == null || isNaN(value)) return css('--no-data');
+  for (let i = 0; i < breaks.length; i++) if (value <= breaks[i]) return ramp[i];
+  return ramp[ramp.length - 1];
+}
+const INV_BREAKS = [0, 5, 50, 500, 2000];         // detections (0 -> lightest)
+const RISK_BREAKS = [0, 0.05, 0.1, 0.2, 0.35];    // dengue risk index
+
+function fmtBreaks(breaks, suffix) {
+  const ramp = SEQ(), rows = [];
+  const label = i => i === 0 ? `${breaks[0]}` :
+      i < breaks.length ? `&le; ${breaks[i]}` : `&gt; ${breaks[breaks.length-1]}`;
+  for (let i = 0; i <= breaks.length; i++)
+    rows.push(`<div class="row"><span class="swatch" style="background:${ramp[i]}"></span>${label(i)}${suffix}</div>`);
+  return rows.join('');
+}
+
+// ---- data load ----
+async function loadAll() {
+  const status = document.getElementById('status');
+  try {
+    const [inv, den] = await Promise.all([
+      fetch(`${API}/invasive/static2`).then(r => r.json()),
+      fetch(`${API}/dengue`).then(r => r.json()),
+    ]);
+    const prep = fc => fc.features
+      .map(f => ({ props: f.properties, rings: featureLatLngs(f) }))
+      .filter(f => f.rings.length && inCalifornia(f.rings));
+    state.invasive = prep(inv);
+    state.dengue = prep(den);
+    status.textContent =
+      `${state.invasive.length} invasive-surveillance regions and ${state.dengue.length} dengue-risk regions in California.`;
+    render();
+  } catch (e) {
+    status.textContent = `Failed to load VectorSurv data: ${e}`;
+  }
+}
+
+function scoped(features) {
+  return state.scope === 'sd' ? features.filter(f => f.props.county === 'San Diego') : features;
+}
+
+function latestRisk(props) {
+  const risk = props.risk || {};
+  let best = null;
+  for (const k of Object.keys(risk)) {
+    const idx = +k;
+    if (best === null || idx > best.idx) best = { idx, ...risk[k] };
+  }
+  return best; // {idx, risk, date} or null
+}
+
+function render() {
+  if (state.mapLayer) { map.removeLayer(state.mapLayer); state.mapLayer = null; }
+  const group = L.featureGroup();
+  const isInv = state.layer === 'invasive';
+  const feats = scoped(isInv ? state.invasive : state.dengue);
+
+  for (const f of feats) {
+    const value = isInv ? +f.props[state.species] || 0 : (latestRisk(f.props)?.risk ?? null);
+    const color = isInv ? seqColor(value, INV_BREAKS) : seqColor(value, RISK_BREAKS);
+    const poly = L.polygon(f.rings, {
+      color: css('--baseline'), weight: 1, fillColor: color, fillOpacity: 0.75,
+    });
+    poly.bindTooltip(`${f.props.subcounty} — ${f.props.county} County`, { sticky: true });
+    poly.on('click', () => select(f));
+    poly.addTo(group);
+  }
+  state.mapLayer = group.addTo(map);
+  if (feats.length) map.fitBounds(group.getBounds().pad(0.05));
+
+  document.getElementById('speciesGroup').style.display = isInv ? '' : 'none';
+  document.getElementById('legend').innerHTML = isInv
+    ? `<div class="row"><b>${document.querySelector('#speciesSel option:checked').textContent}</b></div>` +
+      fmtBreaks(INV_BREAKS, '')
+    : `<div class="row"><b>Latest weekly dengue risk index</b></div>` + fmtBreaks(RISK_BREAKS, '');
+}
+
+// ---- side panel ----
+const panelTitle = document.getElementById('panelTitle');
+const panelSub = document.getElementById('panelSub');
+const panelBody = document.getElementById('panelBody');
+
+async function select(f) {
+  state.selected = f;
+  const p = f.props;
+  panelTitle.textContent = `${p.subcounty} — ${p.county} County`;
+  if (state.layer === 'invasive') {
+    panelSub.textContent = p.agency;
+    const species = [
+      ['Aedes aegypti', 'aegypti'], ['Aedes albopictus', 'albopictus'],
+      ['Aedes notoscriptus', 'notoscriptus'], ['Aedes japonicus', 'japonicus'],
+    ];
+    const rows = species.map(([name, key]) => `
+      <tr><td><i>${name}</i></td>
+          <td class="num">${p[key + '_detections'] ?? 0}</td>
+          <td>${clean(p[key + '_first_found'])}</td>
+          <td>${clean(p[key + '_last_found'])}</td></tr>`).join('');
+    panelBody.innerHTML = `
+      <table>
+        <thead><tr><th>Species</th><th class="num">Detections</th><th>First found</th><th>Last found</th></tr></thead>
+        <tbody>${rows}</tbody>
+      </table>
+      <div class="chart-wrap" id="weeklyChart"><p class="chart-sub">Loading weekly counts…</p></div>`;
+    try {
+      const url = `${API}/invasive/subcounty2/${encodeURIComponent(p.agency)}/${encodeURIComponent(p.subcounty)}/${p.id}`;
+      const detail = await fetch(url).then(r => r.json());
+      drawWeeklyChart(flattenWeeks(detail), document.getElementById('weeklyChart'));
+    } catch (e) {
+      document.getElementById('weeklyChart').innerHTML = `<p class="chart-sub">Weekly counts unavailable (${e}).</p>`;
+    }
+  } else {
+    panelSub.textContent = 'Weekly dengue transmission-risk index (0 = no risk).';
+    const series = Object.values(f.props.risk || {})
+      .filter(e => e && e.date)
+      .map(e => ({ date: new Date(e.date), values: { risk: e.risk } }))
+      .sort((a, b) => a.date - b.date);
+    panelBody.innerHTML = `<div class="chart-wrap" id="riskChart"></div>`;
+    drawLineChart(document.getElementById('riskChart'), series,
+      [{ key: 'risk', label: 'Risk index', color: css('--series-1') }],
+      { title: 'Dengue risk index by week', yLabel: 'risk index' });
+  }
+}
+const clean = v => (v && v !== 'None') ? String(v).slice(0, 10) : '—';
+
+function flattenWeeks(detail) {
+  const rows = [];
+  for (const q of Object.values(detail)) {
+    for (const m of Object.values(q.months || {})) {
+      for (const w of Object.values(m.weeks || {})) {
+        const vals = { aegypti: w.aegypti, notoscriptus: w.notoscriptus, other: w.other };
+        if (Object.values(vals).every(v => v == null)) continue;
+        rows.push({ date: new Date(w.date), values: vals });
+      }
+    }
+  }
+  return rows.sort((a, b) => a.date - b.date);
+}
+
+function drawWeeklyChart(series, el) {
+  if (!series.length) { el.innerHTML = '<p class="chart-sub">No collections reported for this region.</p>'; return; }
+  drawLineChart(el, series, [
+    { key: 'aegypti', label: 'Ae. aegypti', color: css('--series-1') },
+    { key: 'notoscriptus', label: 'Ae. notoscriptus', color: css('--series-2') },
+    { key: 'other', label: 'Other mosquitoes', color: css('--series-3') },
+  ], { title: 'Weekly mosquito counts', yLabel: 'specimens / week' });
+}
+
+// ---- minimal SVG line chart with crosshair tooltip ----
+function drawLineChart(el, rows, seriesDefs, opts) {
+  const W = Math.max(el.clientWidth || 380, 300), H = 190;
+  const m = { top: 10, right: 8, bottom: 22, left: 40 };
+  const x0 = rows[0].date.getTime(), x1 = rows[rows.length - 1].date.getTime() || x0 + 1;
+  let yMax = 0;
+  for (const r of rows) for (const s of seriesDefs) yMax = Math.max(yMax, r.values[s.key] || 0);
+  yMax = yMax || 1;
+  const X = t => m.left + (W - m.left - m.right) * (t - x0) / Math.max(1, x1 - x0);
+  const Y = v => m.top + (H - m.top - m.bottom) * (1 - v / yMax);
+  const ticks = 4;
+  const fmt = v => yMax >= 10 ? Math.round(v) : yMax >= 1 ? v.toFixed(1) : v.toFixed(2);
+  let grid = '';
+  for (let i = 0; i <= ticks; i++) {
+    const v = yMax * i / ticks, y = Y(v);
+    grid += `<line x1="${m.left}" x2="${W - m.right}" y1="${y}" y2="${y}" stroke="${css('--grid')}" stroke-width="1"/>` +
+            `<text x="${m.left - 5}" y="${y + 3}" text-anchor="end" font-size="10" fill="${css('--text-muted')}">${fmt(v)}</text>`;
+  }
+  let xlabels = '';
+  const yearList = [...new Set(rows.map(r => r.date.getFullYear()))];
+  const step = Math.max(1, Math.ceil(yearList.length / 6));
+  for (let i = 0; i < yearList.length; i += step) {
+    const t = new Date(yearList[i], 0, 1).getTime();
+    if (t >= x0 && t <= x1)
+      xlabels += `<text x="${X(t)}" y="${H - 6}" font-size="10" fill="${css('--text-muted')}">${yearList[i]}</text>`;
+  }
+  const paths = seriesDefs.map(s => {
+    let d = '', pen = false;
+    for (const r of rows) {
+      const v = r.values[s.key];
+      if (v == null) { pen = false; continue; }
+      d += `${pen ? 'L' : 'M'}${X(r.date.getTime()).toFixed(1)},${Y(v).toFixed(1)}`;
+      pen = true;
+    }
+    return `<path d="${d}" fill="none" stroke="${s.color}" stroke-width="2" stroke-linejoin="round"/>`;
+  }).join('');
+  const legend = seriesDefs.map(s =>
+    `<span class="row"><span class="chip" style="background:${s.color}"></span>${s.label}</span>`).join('');
+  el.innerHTML = `
+    <div class="chart-title">${opts.title}</div>
+    <div class="chart-sub">${rows[0].date.getFullYear()}–${rows[rows.length-1].date.getFullYear()} · ${opts.yLabel}</div>
+    <div class="chart-legend">${legend}</div>
+    <svg viewBox="0 0 ${W} ${H}" width="100%" role="img" aria-label="${opts.title}">
+      ${grid}
+      <line x1="${m.left}" x2="${W - m.right}" y1="${Y(0)}" y2="${Y(0)}" stroke="${css('--baseline')}" stroke-width="1"/>
+      ${xlabels}${paths}
+      <line id="xh" y1="${m.top}" y2="${H - m.bottom}" stroke="${css('--baseline')}" stroke-width="1" opacity="0"/>
+      <rect x="${m.left}" y="${m.top}" width="${W - m.left - m.right}" height="${H - m.top - m.bottom}" fill="transparent"/>
+    </svg>`;
+  const svg = el.querySelector('svg'), xh = el.querySelector('#xh'), tip = document.getElementById('tooltip');
+  svg.addEventListener('mousemove', ev => {
+    const rect = svg.getBoundingClientRect();
+    const t = x0 + (x1 - x0) * ((ev.clientX - rect.left) / rect.width * W - m.left) / (W - m.left - m.right);
+    let best = rows[0], bd = Infinity;
+    for (const r of rows) { const d = Math.abs(r.date.getTime() - t); if (d < bd) { bd = d; best = r; } }
+    xh.setAttribute('x1', X(best.date.getTime())); xh.setAttribute('x2', X(best.date.getTime()));
+    xh.setAttribute('opacity', 1);
+    tip.style.display = 'block';
+    tip.style.left = (ev.clientX + 14) + 'px'; tip.style.top = (ev.clientY + 10) + 'px';
+    tip.innerHTML = `<div class="t-date">week of ${best.date.toISOString().slice(0,10)}</div>` +
+      seriesDefs.map(s => `<div><span class="chip" style="display:inline-block;width:9px;height:9px;border-radius:3px;background:${s.color}"></span> ${s.label}: <b>${best.values[s.key] ?? '—'}</b></div>`).join('');
+  });
+  svg.addEventListener('mouseleave', () => { xh.setAttribute('opacity', 0); tip.style.display = 'none'; });
+}
+
+// ---- controls ----
+document.getElementById('layerSeg').addEventListener('click', e => {
+  const btn = e.target.closest('button'); if (!btn) return;
+  document.querySelectorAll('#layerSeg button').forEach(b => b.classList.toggle('active', b === btn));
+  state.layer = btn.dataset.layer;
+  panelBody.innerHTML = ''; panelSub.textContent = 'Click a region on the map.';
+  panelTitle.textContent = 'Region detail';
+  render();
+});
+document.getElementById('scopeSeg').addEventListener('click', e => {
+  const btn = e.target.closest('button'); if (!btn) return;
+  document.querySelectorAll('#scopeSeg button').forEach(b => b.classList.toggle('active', b === btn));
+  state.scope = btn.dataset.scope;
+  render();
+});
+document.getElementById('speciesSel').addEventListener('change', e => {
+  state.species = e.target.value; render();
+});
+
+loadAll();
+</script>
+</body>
+</html>

--- a/workflows/pathogens/src/pathogens/assets/__init__.py
+++ b/workflows/pathogens/src/pathogens/assets/__init__.py
@@ -50,6 +50,14 @@ from .screwworm_unified import (
     nws_unified_job,
     nws_unified_schedule,
 )
+from .vectorsurv import (
+    vectorsurv_invasive_regions,
+    vectorsurv_mosquito_counts,
+    vectorsurv_dengue_risk,
+    vectorsurv_arbovirus_activity,
+    vectorsurv_weekly_job,
+    vectorsurv_weekly_schedule,
+)
 from . import cdc_nnds
 
 # respnet and wastewaterscan modules are present but not wired in; enable them

--- a/workflows/pathogens/src/pathogens/assets/vectorsurv.py
+++ b/workflows/pathogens/src/pathogens/assets/vectorsurv.py
@@ -1,0 +1,738 @@
+"""VectorSurv (maps.vectorsurv.org) vector-borne disease surveillance assets.
+
+Pulls the public map-data API that backs https://maps.vectorsurv.org/arbo
+(``https://mathew.vectorsurv.org/v2``) and produces California / San Diego
+focused datasets under the ``pathogens/vectorborne`` S3 path:
+
+* ``vectorsurv_invasive_regions`` — invasive *Aedes* surveillance subcounty
+  polygons for California (decoded from Google encoded polylines) with
+  per-species detection summaries. Stored as GeoJSON + CSV.
+* ``vectorsurv_mosquito_counts`` — weekly invasive-mosquito trap counts by
+  species for every California subcounty region, all years (2010–present),
+  from the per-region ``invasive/subcounty2`` endpoint. Stored as CSV +
+  Parquet.
+* ``vectorsurv_dengue_risk`` — dengue transmission-risk subcounty polygons
+  for California (GeoJSON) plus the full weekly risk-index time series
+  (CSV + Parquet).
+* ``vectorsurv_arbovirus_activity`` — arbovirus surveillance activity
+  (WNV/SLEV/WEEV/... positive mosquito pools, dead birds, sentinel
+  seroconversions) by city and month for all years, filtered to California.
+  Stored as CSV + Parquet + a GeoJSON point layer.
+
+Geometry note: VectorSurv serves polygons as ``EncodedPolyline`` geometries
+(Google polyline5 encoding, one encoded string per ring). These are decoded
+here into standard GeoJSON MultiPolygons so downstream consumers get plain
+GeoJSON.
+
+The mosquito-abundance (AMoR) endpoints of the same API are restricted to
+VectorSurv Gateway account holders and are intentionally not scraped here;
+the invasive weekly counts and arbovirus activity layers are the public
+"mosquito counts" sources.
+"""
+
+import json
+import os
+import time
+from datetime import datetime
+
+import geopandas as gpd
+import pandas as pd
+import requests
+from dagster import (
+    AssetIn,
+    AssetKey,
+    AutomationCondition,
+    Output,
+    RunRequest,
+    asset,
+    define_asset_job,
+    get_dagster_logger,
+    schedule,
+)
+from shapely.geometry import MultiPolygon, Point, Polygon
+
+from resilient_core.utils import store_assets
+
+VECTORSURV_API = "https://mathew.vectorsurv.org/v2"
+VECTORSURV_MAPS_URL = "https://maps.vectorsurv.org"
+
+S3_RAW_PATH = "pathogens/vectorborne/raw/vectorsurv"
+S3_OUTPUT_PATH = "pathogens/vectorborne/output"
+VECTORSURV_LATEST_PATH = "pathogens/vectorborne/vectorsurv"
+
+# The API mixes agencies from many states without a state attribute on the
+# dengue / invasive layers, so features are filtered spatially to California.
+CA_BBOX = {"min_lat": 32.3, "max_lat": 42.1, "min_lon": -124.6, "max_lon": -114.1}
+
+# Optional comma-separated county filter for the (slow) per-region weekly
+# counts pull, e.g. "San Diego,Imperial". Empty/unset = all California.
+COUNTY_FILTER_ENV = "VECTORSURV_COUNTIES"
+
+REQUEST_TIMEOUT = 120
+REQUEST_DELAY_SECONDS = 0.1
+
+# Species keys used by the invasive/subcounty2 weekly records -> full name.
+INVASIVE_SPECIES = {
+    "aegypti": "Aedes aegypti",
+    "albopictus": "Aedes albopictus",
+    "atropalpus": "Aedes atropalpus",
+    "bahamensis": "Aedes bahamensis",
+    "biscaynensis": "Aedes biscaynensis",
+    "coronator": "Aedes coronator",
+    "declarator": "Aedes declarator",
+    "notoscriptus": "Aedes notoscriptus",
+    "interrogator": "Aedes interrogator",
+    "japonicus": "Aedes japonicus",
+    "lactator": "Aedes lactator",
+    "panocossa": "Aedes panocossa",
+    "scapularis": "Aedes scapularis",
+    "squamipennis": "Aedeomyia squamipennis",
+}
+
+# Arbo layer key -> (pathogen, indicator). Layers come from /v2/arbo/.
+ARBO_LAYERS = {
+    "WNVPools": ("West Nile virus", "positive_mosquito_pools"),
+    "WNVBirds": ("West Nile virus", "dead_birds"),
+    "WNVSentinels": ("West Nile virus", "sentinel_seroconversions"),
+    "SLEVPools": ("St. Louis encephalitis virus", "positive_mosquito_pools"),
+    "SLEVSentinels": ("St. Louis encephalitis virus", "sentinel_seroconversions"),
+    "WEEVPools": ("Western equine encephalitis virus", "positive_mosquito_pools"),
+    "WEEVSentinels": ("Western equine encephalitis virus", "sentinel_seroconversions"),
+    "CVVPools": ("Cache Valley virus", "positive_mosquito_pools"),
+    "LACVPools": ("La Crosse virus", "positive_mosquito_pools"),
+    "JCVPools": ("Jamestown Canyon virus", "positive_mosquito_pools"),
+    "EEEVPools": ("Eastern equine encephalitis virus", "positive_mosquito_pools"),
+    "FLAVPools": ("Flanders virus", "positive_mosquito_pools"),
+}
+
+
+# ---------------------------------------------------------------------------
+# Geometry helpers
+# ---------------------------------------------------------------------------
+
+def decode_polyline(encoded: str):
+    """Decode a Google polyline5 string into a list of (lon, lat) tuples."""
+    coords = []
+    index = lat = lon = 0
+    length = len(encoded)
+    while index < length:
+        for is_lon in (False, True):
+            shift = result = 0
+            while True:
+                b = ord(encoded[index]) - 63
+                index += 1
+                result |= (b & 0x1F) << shift
+                shift += 5
+                if b < 0x20:
+                    break
+            delta = ~(result >> 1) if result & 1 else result >> 1
+            if is_lon:
+                lon += delta
+            else:
+                lat += delta
+        coords.append((lon * 1e-5, lat * 1e-5))
+    return coords
+
+
+def encoded_polyline_to_multipolygon(geometry: dict) -> MultiPolygon:
+    """Convert a VectorSurv ``EncodedPolyline`` geometry to a MultiPolygon.
+
+    ``coordinates`` is a list of polygons, each polygon a list of rings, each
+    ring a dict with an encoded ``point`` string (first ring = exterior).
+    """
+    polygons = []
+    for polygon_rings in geometry.get("coordinates", []):
+        rings = []
+        for ring in polygon_rings:
+            points = decode_polyline(ring["point"])
+            if len(points) >= 3:
+                rings.append(points)
+        if rings:
+            polygons.append(Polygon(rings[0], rings[1:]))
+    return MultiPolygon(polygons)
+
+
+def in_california(geom) -> bool:
+    point = geom.representative_point()
+    return (
+        CA_BBOX["min_lat"] <= point.y <= CA_BBOX["max_lat"]
+        and CA_BBOX["min_lon"] <= point.x <= CA_BBOX["max_lon"]
+    )
+
+
+def _get_json(url: str, logger=None, retries: int = 3):
+    for attempt in range(retries):
+        try:
+            response = requests.get(url, timeout=REQUEST_TIMEOUT)
+            response.raise_for_status()
+            return response.json()
+        except Exception as e:  # noqa: BLE001 - retry any network/JSON error
+            if attempt == retries - 1:
+                raise
+            if logger:
+                logger.warning(f"retry {attempt + 1} for {url}: {e}")
+            time.sleep(2 ** attempt)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Pure transforms (unit-testable without Dagster/S3)
+# ---------------------------------------------------------------------------
+
+def invasive_features_to_gdf(feature_collection: dict) -> gpd.GeoDataFrame:
+    """California invasive-Aedes subcounty polygons with detection summaries."""
+    rows = []
+    geometries = []
+    for feature in feature_collection.get("features", []):
+        try:
+            geom = encoded_polyline_to_multipolygon(feature["geometry"])
+        except Exception:
+            continue
+        if geom.is_empty or not in_california(geom):
+            continue
+        props = feature.get("properties", {})
+        row = {
+            "region_id": props.get("id"),
+            "agency": props.get("agency"),
+            "county": props.get("county"),
+            "subcounty": props.get("subcounty"),
+            "surveillance_start": props.get("surveillance_start"),
+            "website": props.get("website"),
+        }
+        for key in INVASIVE_SPECIES:
+            for suffix in ("detections", "first_found", "last_found"):
+                value = props.get(f"{key}_{suffix}")
+                row[f"{key}_{suffix}"] = None if value in ("None", "") else value
+        rows.append(row)
+        geometries.append(geom)
+    gdf = gpd.GeoDataFrame(rows, geometry=geometries, crs="EPSG:4326")
+    for key in INVASIVE_SPECIES:
+        gdf[f"{key}_detections"] = pd.to_numeric(
+            gdf[f"{key}_detections"], errors="coerce"
+        ).fillna(0).astype(int)
+    return gdf
+
+
+def subcounty_detail_to_rows(detail: dict, region: dict) -> list:
+    """Flatten one invasive/subcounty2 response into weekly count rows.
+
+    The response is quarters -> months -> weeks keyed by index since 2010;
+    every level carries an explicit date, so only dates are used. Weeks with
+    no reported counts for any species (all null) are skipped — those are
+    weeks without surveillance, while 0 means surveyed and none collected.
+    """
+    rows = []
+    for quarter in detail.values():
+        for month in quarter.get("months", {}).values():
+            for week_index, week in month.get("weeks", {}).items():
+                counts = {
+                    key: week.get(key)
+                    for key in list(INVASIVE_SPECIES) + ["other"]
+                }
+                if all(value is None for value in counts.values()):
+                    continue
+                date = pd.to_datetime(week.get("date"), errors="coerce")
+                if pd.isna(date):
+                    continue
+                row = {
+                    "week_start": date.date().isoformat(),
+                    "year": date.year,
+                    "week_index": int(week_index),
+                    "week_days": pd.to_numeric(
+                        week.get("week_days"), errors="coerce"
+                    ),
+                    "region_id": region.get("region_id"),
+                    "agency": region.get("agency"),
+                    "county": region.get("county"),
+                    "subcounty": region.get("subcounty"),
+                    "aegypti_growth_index": week.get("aegyptiGrowth"),
+                    "albopictus_growth_index": week.get("alboGrowth"),
+                }
+                row.update(counts)
+                rows.append(row)
+    return rows
+
+
+def dengue_features_to_gdf_and_series(feature_collection: dict):
+    """California dengue-risk polygons (latest risk) plus the weekly series."""
+    rows = []
+    geometries = []
+    series_rows = []
+    for feature in feature_collection.get("features", []):
+        try:
+            geom = encoded_polyline_to_multipolygon(feature["geometry"])
+        except Exception:
+            continue
+        if geom.is_empty or not in_california(geom):
+            continue
+        props = feature.get("properties", {})
+        risk = props.get("risk") or {}
+        latest_week = None
+        for week_index, entry in risk.items():
+            if not isinstance(entry, dict):
+                continue
+            date = pd.to_datetime(entry.get("date"), errors="coerce")
+            if pd.isna(date):
+                continue
+            series_rows.append(
+                {
+                    "region_id": props.get("id"),
+                    "county": props.get("county"),
+                    "subcounty": props.get("subcounty"),
+                    "week_index": int(week_index),
+                    "week_start": date.date().isoformat(),
+                    "year": date.year,
+                    "risk_index": entry.get("risk"),
+                }
+            )
+            if latest_week is None or int(week_index) > latest_week[0]:
+                latest_week = (int(week_index), date, entry.get("risk"))
+        rows.append(
+            {
+                "region_id": props.get("id"),
+                "county": props.get("county"),
+                "subcounty": props.get("subcounty"),
+                "latest_risk_index": latest_week[2] if latest_week else None,
+                "latest_risk_date": (
+                    latest_week[1].date().isoformat() if latest_week else None
+                ),
+            }
+        )
+        geometries.append(geom)
+    gdf = gpd.GeoDataFrame(rows, geometry=geometries, crs="EPSG:4326")
+    series = pd.DataFrame(series_rows)
+    if not series.empty:
+        series = series.sort_values(
+            ["county", "subcounty", "week_index"]
+        ).reset_index(drop=True)
+    return gdf, series
+
+
+def arbo_payload_to_df(payload: dict, states=("CA",)) -> pd.DataFrame:
+    """Flatten /v2/arbo/ into monthly counts per pathogen/indicator/city."""
+    rows = []
+    for layer, collection in payload.items():
+        pathogen, indicator = ARBO_LAYERS.get(layer, (layer, layer))
+        for feature in collection.get("features", []):
+            props = feature.get("properties", {})
+            if states and props.get("state") not in states:
+                continue
+            geometry = feature.get("geometry", {})
+            coords = geometry.get("coordinates", [None, None])
+            monthly = {}
+            for entry in props.get("collections", []):
+                if not isinstance(entry, dict):
+                    continue
+                for label, value in entry.items():
+                    month = pd.to_datetime(label, format="%b %Y", errors="coerce")
+                    if pd.isna(month):
+                        continue
+                    bucket = monthly.setdefault(
+                        month, {"count": 0, "records": 0}
+                    )
+                    bucket["count"] += value or 0
+                    bucket["records"] += 1
+            for month, bucket in monthly.items():
+                rows.append(
+                    {
+                        "pathogen": pathogen,
+                        "indicator": indicator,
+                        "layer": layer,
+                        "city": props.get("city"),
+                        "state": props.get("state"),
+                        "longitude": coords[0],
+                        "latitude": coords[1],
+                        "month_start": month.date().isoformat(),
+                        "year": month.year,
+                        "month": month.month,
+                        "count": bucket["count"],
+                        "n_records": bucket["records"],
+                    }
+                )
+    df = pd.DataFrame(rows)
+    if not df.empty:
+        df = df.sort_values(
+            ["pathogen", "indicator", "city", "month_start"]
+        ).reset_index(drop=True)
+    return df
+
+
+def _metadata(context, name, description=None):
+    """schema.org Dataset metadata via store_assets.objectMetadata.
+
+    Defaults to the asset's own description/source; pass ``description`` for
+    companion datasets (raw snapshots, weekly series, point layers) stored
+    alongside the primary output.
+    """
+    meta = context.assets_def.metadata_by_key[context.asset_key]
+    return store_assets.objectMetadata(
+        name=name,
+        description=description or meta.get("description"),
+        source_url=meta.get("source"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Assets
+# ---------------------------------------------------------------------------
+
+@asset(
+    group_name="vectorborne",
+    key_prefix="vectorsurv",
+    name="vectorsurv_invasive_regions",
+    required_resource_keys={"s3"},
+    metadata={
+        "source": f"{VECTORSURV_API}/invasive/static2",
+        "description": (
+            "Invasive Aedes surveillance subcounty regions for California from "
+            "VectorSurv (maps.vectorsurv.org/invasive). Polygons decoded from "
+            "encoded polylines to GeoJSON, with per-species detection "
+            "summaries (Aedes aegypti, albopictus, notoscriptus, ...)."
+        ),
+    },
+)
+def vectorsurv_invasive_regions(context) -> Output:
+    logger = get_dagster_logger()
+    s3_resource = context.resources.s3
+
+    payload = _get_json(f"{VECTORSURV_API}/invasive/static2", logger)
+    store_assets.raw_to_s3(
+        json.dumps(payload).encode(),
+        f"{S3_RAW_PATH}/invasive_static2.json",
+        s3_resource,
+        contenttype="application/json",
+        metadata=_metadata(
+            context,
+            "vectorsurv_invasive_static2_raw",
+            description=(
+                "Raw VectorSurv invasive/static2 payload (all states, encoded "
+                "polyline geometries) as fetched from the API."
+            ),
+        ),
+    )
+
+    gdf = invasive_features_to_gdf(payload)
+    logger.info(
+        f"{len(gdf)} California invasive regions "
+        f"({gdf['county'].nunique()} counties)"
+    )
+
+    metadata = _metadata(context, "vectorsurv_invasive_regions")
+    store_assets.store_dataframe_to_s3(
+        gdf,
+        f"{S3_OUTPUT_PATH}/vectorsurv_invasive_regions",
+        "vectorsurv_invasive_regions",
+        s3_resource,
+        metadata=metadata,
+        latestdatasetpath=VECTORSURV_LATEST_PATH,
+        enable_latest_path=True,
+        formats=["geojson", "csv"],
+    )
+    return Output(
+        gdf,
+        metadata={
+            "regions": len(gdf),
+            "counties": gdf["county"].nunique(),
+            "aegypti_detections_total": int(gdf["aegypti_detections"].sum()),
+        },
+    )
+
+
+@asset(
+    group_name="vectorborne",
+    key_prefix="vectorsurv",
+    name="vectorsurv_mosquito_counts",
+    ins={
+        "vectorsurv_invasive_regions": AssetIn(
+            key=AssetKey(["vectorsurv", "vectorsurv_invasive_regions"])
+        )
+    },
+    required_resource_keys={"s3"},
+    metadata={
+        "source": f"{VECTORSURV_API}/invasive/subcounty2/",
+        "description": (
+            "Weekly invasive-mosquito trap counts by species for California "
+            "subcounty surveillance regions, all years (2010-present), from "
+            "VectorSurv. Weeks with no surveillance are omitted; a 0 means "
+            "surveyed with none collected. Includes Aedes aegypti/albopictus "
+            "weather-driven growth indexes. Set the VECTORSURV_COUNTIES env "
+            "var (comma separated) to restrict the pull, e.g. 'San Diego'."
+        ),
+    },
+    automation_condition=AutomationCondition.eager(),
+)
+def vectorsurv_mosquito_counts(context, vectorsurv_invasive_regions) -> Output:
+    logger = get_dagster_logger()
+    s3_resource = context.resources.s3
+
+    regions = vectorsurv_invasive_regions.drop(columns="geometry")
+    county_filter = [
+        c.strip()
+        for c in os.environ.get(COUNTY_FILTER_ENV, "").split(",")
+        if c.strip()
+    ]
+    if county_filter:
+        regions = regions[regions["county"].isin(county_filter)]
+        logger.info(f"county filter {county_filter}: {len(regions)} regions")
+
+    all_rows = []
+    failures = []
+    for _, region in regions.iterrows():
+        url = (
+            f"{VECTORSURV_API}/invasive/subcounty2/"
+            f"{requests.utils.quote(str(region['agency']))}/"
+            f"{requests.utils.quote(str(region['subcounty']))}/"
+            f"{region['region_id']}"
+        )
+        try:
+            detail = _get_json(url, logger)
+            all_rows.extend(subcounty_detail_to_rows(detail, region.to_dict()))
+        except Exception as e:  # noqa: BLE001 - keep going, report at the end
+            failures.append(f"{region['agency']}/{region['subcounty']}: {e}")
+        time.sleep(REQUEST_DELAY_SECONDS)
+
+    if failures:
+        logger.warning(
+            f"{len(failures)} regions failed: " + "; ".join(failures[:10])
+        )
+    if not all_rows:
+        raise RuntimeError("no weekly mosquito counts extracted from VectorSurv")
+
+    df = pd.DataFrame(all_rows).sort_values(
+        ["county", "subcounty", "week_start"]
+    ).reset_index(drop=True)
+    logger.info(
+        f"{len(df)} weekly rows across {df['region_id'].nunique()} regions, "
+        f"{df['week_start'].min()} - {df['week_start'].max()}"
+    )
+
+    metadata = _metadata(context, "vectorsurv_mosquito_counts")
+    store_assets.store_dataframe_to_s3(
+        df,
+        f"{S3_OUTPUT_PATH}/vectorsurv_mosquito_counts",
+        "vectorsurv_mosquito_counts",
+        s3_resource,
+        metadata=metadata,
+        latestdatasetpath=VECTORSURV_LATEST_PATH,
+        enable_latest_path=True,
+        formats=["csv", "parquet"],
+    )
+    return Output(
+        df,
+        metadata={
+            "rows": len(df),
+            "regions": int(df["region_id"].nunique()),
+            "first_week": str(df["week_start"].min()),
+            "last_week": str(df["week_start"].max()),
+            "failed_regions": len(failures),
+        },
+    )
+
+
+@asset(
+    group_name="vectorborne",
+    key_prefix="vectorsurv",
+    name="vectorsurv_dengue_risk",
+    required_resource_keys={"s3"},
+    metadata={
+        "source": f"{VECTORSURV_API}/dengue",
+        "description": (
+            "Dengue transmission-risk subcounty regions for California from "
+            "VectorSurv (maps.vectorsurv.org/dengue). GeoJSON polygons carry "
+            "the most recent weekly risk index; the companion "
+            "vectorsurv_dengue_risk_weekly CSV/Parquet table has the full "
+            "weekly risk-index series per region."
+        ),
+    },
+)
+def vectorsurv_dengue_risk(context) -> Output:
+    logger = get_dagster_logger()
+    s3_resource = context.resources.s3
+
+    payload = _get_json(f"{VECTORSURV_API}/dengue", logger)
+    store_assets.raw_to_s3(
+        json.dumps(payload).encode(),
+        f"{S3_RAW_PATH}/dengue.json",
+        s3_resource,
+        contenttype="application/json",
+        metadata=_metadata(
+            context,
+            "vectorsurv_dengue_raw",
+            description=(
+                "Raw VectorSurv dengue payload (all states, encoded polyline "
+                "geometries, weekly risk series) as fetched from the API."
+            ),
+        ),
+    )
+
+    gdf, series = dengue_features_to_gdf_and_series(payload)
+    logger.info(
+        f"{len(gdf)} California dengue regions, {len(series)} weekly risk rows"
+    )
+
+    metadata = _metadata(context, "vectorsurv_dengue_risk")
+    store_assets.store_dataframe_to_s3(
+        gdf,
+        f"{S3_OUTPUT_PATH}/vectorsurv_dengue_risk",
+        "vectorsurv_dengue_risk",
+        s3_resource,
+        metadata=metadata,
+        latestdatasetpath=VECTORSURV_LATEST_PATH,
+        enable_latest_path=True,
+        formats=["geojson", "csv"],
+    )
+    store_assets.store_dataframe_to_s3(
+        series,
+        f"{S3_OUTPUT_PATH}/vectorsurv_dengue_risk",
+        "vectorsurv_dengue_risk_weekly",
+        s3_resource,
+        metadata=_metadata(
+            context,
+            "vectorsurv_dengue_risk_weekly",
+            description=(
+                "Weekly dengue transmission-risk index time series per "
+                "California subcounty surveillance region from VectorSurv "
+                "(week_start, risk_index; 0 = no risk)."
+            ),
+        ),
+        latestdatasetpath=VECTORSURV_LATEST_PATH,
+        enable_latest_path=True,
+        formats=["csv", "parquet"],
+    )
+    return Output(
+        gdf,
+        metadata={
+            "regions": len(gdf),
+            "weekly_rows": len(series),
+            "counties": gdf["county"].nunique(),
+        },
+    )
+
+
+@asset(
+    group_name="vectorborne",
+    key_prefix="vectorsurv",
+    name="vectorsurv_arbovirus_activity",
+    required_resource_keys={"s3"},
+    metadata={
+        "source": f"{VECTORSURV_API}/arbo/",
+        "description": (
+            "Arbovirus surveillance activity from VectorSurv "
+            "(maps.vectorsurv.org/arbo): monthly counts of positive mosquito "
+            "pools, dead birds and sentinel seroconversions by city for WNV, "
+            "SLEV, WEEV and other arboviruses, all years, filtered to "
+            "California."
+        ),
+    },
+)
+def vectorsurv_arbovirus_activity(context) -> Output:
+    logger = get_dagster_logger()
+    s3_resource = context.resources.s3
+
+    payload = _get_json(f"{VECTORSURV_API}/arbo/", logger)
+    store_assets.raw_to_s3(
+        json.dumps(payload).encode(),
+        f"{S3_RAW_PATH}/arbo.json",
+        s3_resource,
+        contenttype="application/json",
+        metadata=_metadata(
+            context,
+            "vectorsurv_arbo_raw",
+            description=(
+                "Raw VectorSurv arbo payload: per-city point features with "
+                "monthly collection counts for 12 arbovirus surveillance "
+                "layers (all states), as fetched from the API."
+            ),
+        ),
+    )
+
+    df = arbo_payload_to_df(payload, states=("CA",))
+    if df.empty:
+        raise RuntimeError("no California arbovirus activity rows extracted")
+    logger.info(
+        f"{len(df)} monthly rows, {df['year'].min()}-{df['year'].max()}, "
+        f"pathogens: {sorted(df['pathogen'].unique())}"
+    )
+
+    metadata = _metadata(context, "vectorsurv_arbovirus_activity")
+    store_assets.store_dataframe_to_s3(
+        df,
+        f"{S3_OUTPUT_PATH}/vectorsurv_arbovirus_activity",
+        "vectorsurv_arbovirus_activity",
+        s3_resource,
+        metadata=metadata,
+        latestdatasetpath=VECTORSURV_LATEST_PATH,
+        enable_latest_path=True,
+        formats=["csv", "parquet"],
+    )
+
+    # Point layer aggregated per city/pathogen/indicator for mapping.
+    points = (
+        df.groupby(
+            ["pathogen", "indicator", "layer", "city", "state",
+             "longitude", "latitude"],
+            as_index=False,
+        )
+        .agg(
+            total_count=("count", "sum"),
+            first_year=("year", "min"),
+            last_year=("year", "max"),
+        )
+    )
+    points_gdf = gpd.GeoDataFrame(
+        points,
+        geometry=[Point(xy) for xy in zip(points["longitude"], points["latitude"])],
+        crs="EPSG:4326",
+    )
+    store_assets.store_dataframe_to_s3(
+        points_gdf,
+        f"{S3_OUTPUT_PATH}/vectorsurv_arbovirus_activity",
+        "vectorsurv_arbovirus_activity_points",
+        s3_resource,
+        metadata=_metadata(
+            context,
+            "vectorsurv_arbovirus_activity_points",
+            description=(
+                "GeoJSON point layer of California arbovirus surveillance "
+                "activity aggregated per city, pathogen and indicator "
+                "(total_count, first_year, last_year) from VectorSurv."
+            ),
+        ),
+        latestdatasetpath=VECTORSURV_LATEST_PATH,
+        enable_latest_path=True,
+        formats=["geojson", "csv"],
+    )
+    return Output(
+        df,
+        metadata={
+            "rows": len(df),
+            "cities": int(df["city"].nunique()),
+            "years": f"{int(df['year'].min())}-{int(df['year'].max())}",
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Job + weekly schedule
+# ---------------------------------------------------------------------------
+
+vectorsurv_weekly_job = define_asset_job(
+    "vectorsurv_weekly_job",
+    selection=[
+        AssetKey(["vectorsurv", "vectorsurv_invasive_regions"]),
+        AssetKey(["vectorsurv", "vectorsurv_mosquito_counts"]),
+        AssetKey(["vectorsurv", "vectorsurv_dengue_risk"]),
+        AssetKey(["vectorsurv", "vectorsurv_arbovirus_activity"]),
+    ],
+)
+
+
+@schedule(
+    job=vectorsurv_weekly_job,
+    cron_schedule="0 6 * * 1",
+    name="vectorsurv_weekly_schedule",
+    execution_timezone="America/Los_Angeles",
+)
+def vectorsurv_weekly_schedule(context):
+    """VectorSurv refreshes continuously; Monday 6am PT catches the prior week."""
+    return RunRequest(run_key=f"vectorsurv_{datetime.now().date().isoformat()}")

--- a/workflows/pathogens/src/pathogens/definitions.py
+++ b/workflows/pathogens/src/pathogens/definitions.py
@@ -74,6 +74,7 @@ defs = Definitions(
         assets_pkg.nws_dashboard_job,
         assets_pkg.nws_omsa_job,
         assets_pkg.nws_unified_job,
+        assets_pkg.vectorsurv_weekly_job,
     ],
     schedules=[
         assets_pkg.cdc_nndss_weekly_schedule,
@@ -84,6 +85,7 @@ defs = Definitions(
         assets_pkg.nws_dashboard_schedule,
         assets_pkg.nws_omsa_schedule,
         assets_pkg.nws_unified_schedule,
+        assets_pkg.vectorsurv_weekly_schedule,
     ],
     sensors=[slack_on_run_failure, assets_pkg.wahis_upload_sensor, assets_pkg.mpox_upstream_sensor],
 )


### PR DESCRIPTION
## Summary
Adds comprehensive VectorSurv (maps.vectorsurv.org) data ingestion to the pathogens code location, pulling public surveillance data on invasive *Aedes* mosquitoes, dengue transmission risk, and arbovirus activity across California. Includes four new Dagster assets with weekly scheduling, plus interactive prototype visualizations.

## Key Changes

### New Assets (`workflows/pathogens/src/pathogens/assets/vectorsurv.py`)
- **`vectorsurv_invasive_regions`**: Subcounty surveillance polygons for invasive *Aedes* species (aegypti, albopictus, notoscriptus, etc.) with per-species detection summaries. Decodes Google polyline5 geometries to GeoJSON.
- **`vectorsurv_mosquito_counts`**: Weekly trap counts by species for all California subcounty regions (2010–present), with optional county filtering via `VECTORSURV_COUNTIES` environment variable. Includes growth indexes for aegypti/albopictus.
- **`vectorsurv_dengue_risk`**: Dengue transmission-risk subcounty polygons with latest risk index plus full weekly risk-index time series.
- **`vectorsurv_arbovirus_activity`**: Arbovirus surveillance (WNV, SLEV, WEEV, CVV, LACV, JCV, EEEV, FLAV) by city and month—positive mosquito pools, dead birds, sentinel seroconversions—filtered to California.

All assets store data in multiple formats (CSV, GeoJSON, Parquet) to S3 with schema.org metadata and support the `pathogens/vectorborne` output path structure.

### Implementation Details
- **Geometry handling**: Implements `decode_polyline()` to convert VectorSurv's encoded polyline5 format to standard GeoJSON MultiPolygons for downstream consumers.
- **Spatial filtering**: Uses California bounding box (32.3–42.1°N, -124.6–-114.1°W) to filter multi-state API responses.
- **Data transforms**: Pure, unit-testable functions (`invasive_features_to_gdf()`, `subcounty_detail_to_rows()`, `dengue_features_to_gdf_and_series()`, `arbo_payload_to_df()`) separate API parsing from Dagster orchestration.
- **Resilience**: Retry logic with exponential backoff for network requests; per-region failure tracking for the slow weekly counts pull.
- **Scheduling**: Weekly automation via `AutomationCondition.eager()` for mosquito counts; standard scheduling for static/risk layers.

### Prototype Visualizations (`prototypes/vectorsurv/`)
- **`dengue_invasive.html`**: Interactive Leaflet map of invasive *Aedes* surveillance regions and dengue risk polygons (San Diego/California toggle). Click regions to view species detection history and weekly mosquito count charts.
- **`arbovirus.html`**: Arbovirus activity map with pathogen/year/scope filters. Marker size scales with positives; click for stacked-bar charts and top-cities tables.
- **`README.md`**: Documentation for running the prototypes locally.

Both prototypes decode polylines client-side and read the public VectorSurv API directly (CORS-enabled).

### Integration
- Updated `workflows/pathogens/src/pathogens/assets/__init__.py` to export new assets and weekly job.
- Updated `workflows/pathogens/src/pathogens/definitions.py` to include `vectorsurv_weekly_job` in the definitions.

## Notes
- The mosquito-abundance (AMoR) endpoints are restricted to VectorSurv Gateway account holders and are intentionally not scraped.
- Weeks without surveillance are omitted from weekly series; 0 means surveyed with none collected.
- Raw API payloads are stored alongside processed outputs for auditability.

https://claude.ai/code/session_01RNMMAthi4ZLsxt24auZuTs